### PR TITLE
Makefile: add MANDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .POSIX:
 
 PREFIX=/usr/local
+MANDIR=$(PREFIX)/share/man
 ALL_CFLAGS=$(CFLAGS) -Wall -Wextra -std=c99 -pedantic -D_POSIX_C_SOURCE=200809L
 OBJ=\
 	build.o\
@@ -24,8 +25,8 @@ samu: $(OBJ)
 install: samu samu.1
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	cp samu $(DESTDIR)$(PREFIX)/bin/
-	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
-	cp samu.1 $(DESTDIR)$(PREFIX)/share/man/man1/
+	mkdir -p $(DESTDIR)$(MANDIR)/man1
+	cp samu.1 $(DESTDIR)$(MANDIR)/man1/
 
 clean:
 	rm -f samu $(OBJ)


### PR DESCRIPTION
Allows cleaner installation on Exherbo by decoupling Arch-specific and Any-Arch files.

example:
```
>>> Merging to /
=>> [dir] /usr
=>> [dir] /usr/x86_64-pc-linux-gnu
=>> [dir] /usr/x86_64-pc-linux-gnu/bin
>-> [obj] /usr/x86_64-pc-linux-gnu/bin/samu
=>> [dir] /usr/x86_64-pc-linux-gnu/lib
=>> [dir] /usr/x86_64-pc-linux-gnu/lib/debug
=>> [dir] /usr/x86_64-pc-linux-gnu/lib/debug/usr
=>> [dir] /usr/x86_64-pc-linux-gnu/lib/debug/usr/x86_64-pc-linux-gnu
=>> [dir] /usr/x86_64-pc-linux-gnu/lib/debug/usr/x86_64-pc-linux-gnu/bin
>-> [obj] /usr/x86_64-pc-linux-gnu/lib/debug/usr/x86_64-pc-linux-gnu/bin/samu.debug
=>> [dir] /usr/share
=>> [dir] /usr/share/man
=>> [dir] /usr/share/man/man1
>-> [obj] /usr/share/man/man1/samu.1
=>> [dir] /usr/share/doc
>^> [obj] /usr/share/doc/samurai-scm/README.md
>-> [dir] /usr/share/doc/samurai-scm
```