### PR TITLE
add a --version option to print a compatible ninja version

### DIFF
--- a/samurai.c
+++ b/samurai.c
@@ -18,6 +18,8 @@
 #include "tool.h"
 #include "util.h"
 
+#define NINJA_VERSION "1.8.2"
+
 char *argv0;
 
 static void
@@ -95,6 +97,14 @@ main(int argc, char *argv[])
 	argv0 = strrchr(argv[0], '/');
 	argv0 = argv0 ? argv0 + 1 : argv[0];
 	ARGBEGIN {
+	case '-':
+		if (strcmp(&argv[0][1], "version") == 0) {
+			puts(NINJA_VERSION);
+			exit(0);
+		} else {
+			usage();
+		}
+		break;
 	case 'C':
 		if (chdir(EARGF(usage())) < 0)
 			err(1, "chdir");


### PR DESCRIPTION
cmake needs the --version option to detect ninja, for example:

  cmake -G Ninja -DCMAKE_MAKE_PROGRAM=samu ..