### PR TITLE
Reduce an errx to warnx in parse.c to match default Ninja behavior.

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -108,7 +108,7 @@ parseedge(struct environment *env)
 		canonpath(s);
 		*n = mknode(s);
 		if ((*n)->gen)
-			errx(1, "multiple rules generate '%s'", (*n)->path->s);
+			warnx("multiple rules generate '%s'", (*n)->path->s);
 		(*n)->gen = e;
 	}
 


### PR DESCRIPTION
Hi --

Some of us in OpenBSD land are seriously considering replacing Ninja with Samurai as our default Ninja tool for building third-party packages that use CMake and other Ninja-compatible build tools. See https://marc.info/?l=openbsd-ports&m=153792369811741&w=2 for the thread on the matter. Note that we have already imported Samurai into our ports tree, with me as package maintainer.

In preparation to make that switch, we noticed that there is diverging default behavior between Ninja and Samurai in the event that multiple rules generate a file/target. Ninja by default will warn about this, but continue, providing a
```
ninja: warning: multiple rules generate xxx. builds involving this target will not be correct; continuing anyway [-w dupbuild=warn]
```
diagnostic message, where `xxx` is the name of the file/target. While Ninja does provide a facility to promote a warning to an error, the default behavior is to warn but continue.

Samurai, in contrast, provides a diagnostic message that reads
```
samu: multiple rules generate 'xxx'
```
and then errors out, providing a return code of 1.

This PR is simply the diff I provided in that mailing list email above, reducing the errx to a warnx to match Ninja's default behavior. With this, there is only a single piece of software, webkitgtk4, that fails to build with Samurai, and which I will look into.

A small repo that exhibits this multiple rules issue is https://github.com/never-lang/never if you'd like to look into it yourself.

Thanks!