### PR TITLE
Makefile: Allow overriding PREFIX and MANDIR by build-systems.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .POSIX:
 
-PREFIX=/usr/local
-MANDIR=$(PREFIX)/share/man
+PREFIX?=/usr/local
+MANDIR?=$(PREFIX)/share/man
 ALL_CFLAGS=$(CFLAGS) -Wall -Wextra -std=c99 -pedantic
 OBJ=\
 	build.o\


### PR DESCRIPTION
improve building in pkgsrc with less SUBST_SED usage.