### PR TITLE
DRAFT: Add minimal reproc proof-of-concept integration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PREFIX=/usr/local
 MANDIR=$(PREFIX)/share/man
-ALL_CFLAGS=$(CFLAGS) -Wall -Wextra -std=c99 -pedantic
+ALL_CFLAGS=$(CFLAGS) -Wall -Wextra -std=c99 -pedantic -Ireproc/include
 OBJ=\
 	build.o\
 	deps.o\
@@ -15,7 +15,17 @@ OBJ=\
 	scan.o\
 	tool.o\
 	tree.o\
-	util.o
+	util.o\
+	reproc/src/clock.posix.o\
+	reproc/src/error.posix.o\
+	reproc/src/handle.posix.o\
+	reproc/src/init.posix.o\
+	reproc/src/pipe.posix.o\
+	reproc/src/process.posix.o\
+	reproc/src/redirect.posix.o\
+	reproc/src/reproc.o\
+	reproc/src/run.o\
+	reproc/src/sink.o
 HDR=\
 	arg.h\
 	build.h\
@@ -28,7 +38,19 @@ HDR=\
 	scan.h\
 	tool.h\
 	tree.h\
-	util.h
+	util.h\
+	reproc/include/reproc/export.h\
+	reproc/include/reproc/reproc.h\
+	reproc/include/reproc/run.h\
+	reproc/include/reproc/sink.h\
+	reproc/src/clock.h\
+	reproc/src/error.h\
+	reproc/src/handle.h\
+	reproc/src/init.h\
+	reproc/src/macro.h\
+	reproc/src/pipe.h\
+	reproc/src/process.h\
+	reproc/src/redirect.h
 
 .c.o:
 	$(CC) $(ALL_CFLAGS) -c -o $@ $<

--- a/reproc/include/reproc/export.h
+++ b/reproc/include/reproc/export.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifndef REPROC_EXPORT
+  #ifdef _WIN32
+    #ifdef REPROC_SHARED
+      #ifdef REPROC_BUILDING
+        #define REPROC_EXPORT __declspec(dllexport)
+      #else
+        #define REPROC_EXPORT __declspec(dllimport)
+      #endif
+    #else
+      #define REPROC_EXPORT
+    #endif
+  #else
+    #ifdef REPROC_BUILDING
+      #define REPROC_EXPORT __attribute__((visibility("default")))
+    #else
+      #define REPROC_EXPORT
+    #endif
+  #endif
+#endif

--- a/reproc/include/reproc/reproc.h
+++ b/reproc/include/reproc/reproc.h
@@ -1,0 +1,453 @@
+#pragma once
+
+#include <reproc/export.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! Used to store information about a child process. `reproc_t` is an opaque
+type and can be allocated and released via `reproc_new` and `reproc_destroy`
+respectively. */
+typedef struct reproc_t reproc_t;
+
+/*! reproc error naming follows POSIX errno naming prefixed with `REPROC`. */
+
+/*! An invalid argument was passed to an API function */
+REPROC_EXPORT extern const int REPROC_EINVAL;
+/*! A timeout value passed to an API function expired. */
+REPROC_EXPORT extern const int REPROC_ETIMEDOUT;
+/*! The child process closed one of its streams (and in the case of
+stdout/stderr all of the data remaining in that stream has been read). */
+REPROC_EXPORT extern const int REPROC_EPIPE;
+/*! A memory allocation failed. */
+REPROC_EXPORT extern const int REPROC_ENOMEM;
+/*! A call to `reproc_read` or `reproc_write` would have blocked. */
+REPROC_EXPORT extern const int REPROC_EWOULDBLOCK;
+
+/*! Signal exit status constants. */
+
+REPROC_EXPORT extern const int REPROC_SIGKILL;
+REPROC_EXPORT extern const int REPROC_SIGTERM;
+
+/*! Tells a function that takes a timeout value to wait indefinitely. */
+REPROC_EXPORT extern const int REPROC_INFINITE;
+/*! Tells `reproc_wait` to wait until the deadline passed to `reproc_start`
+expires. */
+REPROC_EXPORT extern const int REPROC_DEADLINE;
+
+/*! Stream identifiers used to indicate which stream to act on. */
+typedef enum {
+  /*! stdin */
+  REPROC_STREAM_IN,
+  /*! stdout */
+  REPROC_STREAM_OUT,
+  /*! stderr */
+  REPROC_STREAM_ERR
+} REPROC_STREAM;
+
+/*! Used to tell reproc where to redirect the streams of the child process. */
+typedef enum {
+  /*! Redirect to a pipe. */
+  REPROC_REDIRECT_PIPE = 1,
+  /*! Redirect to the corresponding stream from the parent process. */
+  REPROC_REDIRECT_PARENT,
+  /*! Redirect to /dev/null (or NUL on Windows). */
+  REPROC_REDIRECT_DISCARD,
+  /*! Redirect to a handle (fd on Linux, HANDLE/SOCKET on Windows). */
+  REPROC_REDIRECT_HANDLE,
+  /*! Redirect to a `FILE *`. */
+  REPROC_REDIRECT_FILE,
+  /*! Redirect to child process stdout. Only valid for stderr. */
+  REPROC_REDIRECT_STDOUT
+} REPROC_REDIRECT;
+
+/*! Used to tell `reproc_stop` how to stop a child process. */
+typedef enum {
+  /*! noop (no operation) */
+  REPROC_STOP_NOOP,
+  /*! `reproc_wait` */
+  REPROC_STOP_WAIT,
+  /*! `reproc_terminate` */
+  REPROC_STOP_TERMINATE,
+  /*! `reproc_kill` */
+  REPROC_STOP_KILL,
+} REPROC_STOP;
+
+typedef struct reproc_stop_action {
+  REPROC_STOP action;
+  int timeout;
+} reproc_stop_action;
+
+typedef struct reproc_stop_actions {
+  reproc_stop_action first;
+  reproc_stop_action second;
+  reproc_stop_action third;
+} reproc_stop_actions;
+
+#if defined(_WIN32)
+typedef void *reproc_handle; // `HANDLE`
+#else
+typedef int reproc_handle; // fd
+#endif
+
+typedef struct reproc_redirect {
+  /*! Type of redirection. if `type` is unset, it defaults to
+  `REPROC_REDIRECT_PIPE`. */
+  REPROC_REDIRECT type;
+  /*!
+  Redirect a stream to an operating system handle. The given handle must be in
+  blocking mode ( `O_NONBLOCK` and `OVERLAPPED` handles are not supported).
+
+  Note that reproc does not take ownership of the handle. The user is
+  responsible for closing the handle after passing it to `reproc_start`. Since
+  the operating system will copy the handle to the child process, the handle
+  can be closed immediately after calling `reproc_start` if the handle is not
+  needed in the parent process anymore.
+
+  If `handle` is set, `type` must be unset or set to `REPROC_REDIRECT_HANDLE`
+  and `file` must be unset.
+  */
+  reproc_handle handle;
+  /*!
+  Redirect a stream to a file stream.
+
+  Note that reproc does not take ownership of the file. The user is
+  responsible for closing the file after passing it to `reproc_start`. Just
+  like with `handles`, the operating system will copy the file handle to the
+  child process so the file can be closed immediately after calling
+  `reproc_start` if it isn't needed anymore by the parent process.
+
+  Any file passed to `file.in` must have been opened in read mode. Likewise,
+  any files passed to `file.out` or `file.err` must have been opened in write
+  mode.
+
+  If `file` is set, `type` must be unset or set to `REPROC_REDIRECT_FILE` and
+  `handle` must be unset.
+  */
+  FILE *file;
+} reproc_redirect;
+
+typedef struct reproc_options {
+  /*!
+  `environment` is an array of UTF-8 encoded, null terminated strings that
+  specifies the environment for the child process. It has the following layout:
+
+  - All elements except the final element must be of the format `NAME=VALUE`.
+  - The final element must be `NULL`.
+
+  Example: ["IP=127.0.0.1", "PORT=8080", `NULL`]
+
+  If `environment` is `NULL`, the child process inherits the environment of the
+  current process.
+  */
+  const char *const *environment;
+  /*!
+  `working_directory` specifies the working directory for the child process. If
+  `working_directory` is `NULL`, the child process runs in the working directory
+  of the parent process.
+  */
+  const char *working_directory;
+  /*!
+  `redirect` specifies where to redirect the streams from the child process.
+
+  By default each stream is redirected to a pipe which can be written to (stdin)
+  or read from (stdout/stderr) using `reproc_write` and `reproc_read`
+  respectively.
+  */
+  struct {
+    /*!
+    `in`, `out` and `err` specify where to redirect the standard I/O streams of
+    the child process. When not set, each of them defaults to
+    `REPROC_REDIRECT_PIPE`.
+    */
+    reproc_redirect in;
+    reproc_redirect out;
+    reproc_redirect err;
+    /*!
+    Use `REPROC_REDIRECT_PARENT` instead of `REPROC_REDIRECT_PIPE` when `type`
+    is unset.
+
+    When this option is set, `discard` may not be set.
+    */
+    bool parent;
+    /*!
+    Use `REPROC_REDIRECT_DISCARD` instead of `REPROC_REDIRECT_PIPE` when `type`
+    is unset.
+
+    When this option is set, `parent` may not be set.
+    */
+    bool discard;
+    /*!
+    Shorthand for redirecting stdout and stderr to the same file.
+
+    If this option is set, `out` and `err` must be unset.
+    */
+    FILE *file;
+  } redirect;
+  /*!
+  Stop actions that are passed to `reproc_stop` in `reproc_destroy` to stop the
+  child process.
+
+  When `stop` is 3x `REPROC_STOP_NOOP`, `reproc_destroy` will default to
+  waiting indefinitely for the child process to exit.
+  */
+  reproc_stop_actions stop;
+  /*!
+  Maximum duration in milliseconds to wait for a single `reproc_poll` operation
+  to complete. If the timeout expires, the call to `reproc_poll` returns
+  `REPROC_ETIMEDOUT`.
+
+  When `timeout` is zero, `reproc_read` and `reproc_write` will wait
+  indefinitely for any I/O to complete.
+  */
+  int timeout;
+  /*!
+  Maximum allowed duration in milliseconds the process is allowed to run in
+  milliseconds. If the deadline is exceeded, Any ongoing and future calls to
+  `reproc_read` and `reproc_write` return `REPROC_ETIMEDOUT`.
+
+  When `deadline` is zero, no deadline is set for the process.
+  */
+  int deadline;
+  /*!
+  `input` is written to the stdin pipe before the child process is started.
+
+  Because `input` is written to the stdin pipe before the process starts,
+  `input.size` must be smaller than the system's default pipe size (64KB).
+
+  If `input` is set, the stdin pipe is closed after `input` is written to it.
+
+  If `redirect.in` is set, this option may not be set.
+  */
+  struct {
+    const uint8_t *data;
+    size_t size;
+  } input;
+  /*!
+  This option can only be used on POSIX systems. If enabled on Windows, an error
+  will be returned.
+
+  If `fork` is enabled, `reproc_start` forks a child process and returns 0 in
+  the child process and > 0 in the parent process. In the child process, only
+  `reproc_destroy` may be called on the `reproc_t` instance to free its
+  associated memory.
+
+  When `fork` is enabled. `argv` must be `NULL` when calling `reproc_start`.
+  */
+  bool fork;
+} reproc_options;
+
+enum {
+  /*! Data can be written to stdin. */
+  REPROC_EVENT_IN = 1 << 0,
+  /*! Data can be read from stdout. */
+  REPROC_EVENT_OUT = 1 << 1,
+  /*! Data can be read from stderr. */
+  REPROC_EVENT_ERR = 1 << 2,
+  /*! The process finished running. */
+  REPROC_EVENT_EXIT = 1 << 3,
+  /*! The deadline or timeout of the process expired. This event is added by
+  default to the list of interested events. */
+  REPROC_EVENT_TIMEOUT = 1 << 4,
+};
+
+typedef struct reproc_event_source {
+  /*! Process to poll for events. */
+  reproc_t *process;
+  /*! Events of the process that we're interested in. Takes a combo of
+  `REPROC_EVENT` flags. */
+  int interests;
+  /*! Combo of `REPROC_EVENT` flags that indicate the events that occurred. This
+  field is filled in by `reproc_poll`. */
+  int events;
+} reproc_event_source;
+
+/*! Allocate a new `reproc_t` instance on the heap. */
+REPROC_EXPORT reproc_t *reproc_new(void);
+
+/*!
+Starts the process specified by `argv` in the given working directory and
+redirects its input, output and error streams.
+
+If this function does not return an error the child process will have started
+running and can be inspected using the operating system's tools for process
+inspection (e.g. ps on Linux).
+
+Every successful call to this function should be followed by a successful call
+to `reproc_wait` or `reproc_stop` and a call to `reproc_destroy`. If an error
+occurs during `reproc_start` all allocated resources are cleaned up before
+`reproc_start` returns and no further action is required.
+
+`argv` is an array of UTF-8 encoded, null terminated strings that specifies the
+program to execute along with its arguments. It has the following layout:
+
+- The first element indicates the executable to run as a child process. This can
+be an absolute path, a path relative to the working directory of the parent
+process or the name of an executable located in the PATH. It cannot be `NULL`.
+- The following elements indicate the whitespace delimited arguments passed to
+the executable. None of these elements can be `NULL`.
+- The final element must be `NULL`.
+
+Example: ["cmake", "-G", "Ninja", "-DCMAKE_BUILD_TYPE=Release", `NULL`]
+*/
+REPROC_EXPORT int reproc_start(reproc_t *process,
+                               const char *const *argv,
+                               reproc_options options);
+
+/*!
+Polls each process in `sources` for its corresponding events in `interests` and
+stores events that occurred for each process in `events`.
+
+Returns `REPROC_EPIPE` if none of the sources have valid pipes remaining that
+can be polled.
+
+Actionable errors:
+- `REPROC_EPIPE`
+*/
+REPROC_EXPORT int reproc_poll(reproc_event_source *sources, size_t num_sources);
+
+/*!
+Reads up to `size` bytes into `buffer` from the child process output stream
+indicated by `stream`.
+
+Actionable errors:
+- `REPROC_EPIPE`
+- `REPROC_EWOULDBLOCK`
+*/
+REPROC_EXPORT int reproc_read(reproc_t *process,
+                              REPROC_STREAM stream,
+                              uint8_t *buffer,
+                              size_t size);
+
+/*!
+Writes up to `size` bytes from `buffer` to the standard input (stdin) of the
+child process.
+
+(POSIX) By default, writing to a closed stdin pipe terminates the parent process
+with the `SIGPIPE` signal. `reproc_write` will only return `REPROC_EPIPE` if
+this signal is ignored by the parent process.
+
+Returns the amount of bytes written. If `buffer` is `NULL` and `size` is zero,
+this function returns 0.
+
+If the standard input of the child process wasn't opened with
+`REPROC_REDIRECT_PIPE`, this function returns `REPROC_EPIPE` unless `buffer` is
+`NULL` and `size` is zero.
+
+Actionable errors:
+- `REPROC_EPIPE`
+- `REPROC_EWOULDBLOCK`
+*/
+REPROC_EXPORT int
+reproc_write(reproc_t *process, const uint8_t *buffer, size_t size);
+
+/*!
+Closes the child process standard stream indicated by `stream`.
+
+This function is necessary when a child process reads from stdin until it is
+closed. After writing all the input to the child process using `reproc_write`,
+the standard input stream can be closed using this function.
+*/
+REPROC_EXPORT int reproc_close(reproc_t *process, REPROC_STREAM stream);
+
+/*!
+Waits `timeout` milliseconds for the child process to exit. If the child process
+has already exited or exits within the given timeout, its exit status is
+returned.
+
+If `timeout` is 0, the function will only check if the child process is still
+running without waiting. If `timeout` is `REPROC_INFINITE`, this function will
+wait indefinitely for the child process to exit. If `timeout` is
+`REPROC_DEADLINE`, this function waits until the deadline passed to
+`reproc_start` expires.
+
+Actionable errors:
+- `REPROC_ETIMEDOUT`
+*/
+REPROC_EXPORT int reproc_wait(reproc_t *process, int timeout);
+
+/*!
+Sends the `SIGTERM` signal (POSIX) or the `CTRL-BREAK` signal (Windows) to the
+child process. Remember that successful calls to `reproc_wait` and
+`reproc_destroy` are required to make sure the child process is completely
+cleaned up.
+*/
+REPROC_EXPORT int reproc_terminate(reproc_t *process);
+
+/*!
+Sends the `SIGKILL` signal to the child process (POSIX) or calls
+`TerminateProcess` (Windows) on the child process. Remember that successful
+calls to `reproc_wait` and `reproc_destroy` are required to make sure the child
+process is completely cleaned up.
+*/
+REPROC_EXPORT int reproc_kill(reproc_t *process);
+
+/*!
+Simplifies calling combinations of `reproc_wait`, `reproc_terminate` and
+`reproc_kill`. The function executes each specified step and waits (using
+`reproc_wait`) until the corresponding timeout expires before continuing with
+the next step.
+
+Example:
+
+Wait 10 seconds for the child process to exit on its own before sending
+`SIGTERM` (POSIX) or `CTRL-BREAK` (Windows) and waiting five more seconds for
+the child process to exit.
+
+```c
+REPROC_ERROR error = reproc_stop(process,
+                                 REPROC_STOP_WAIT, 10000,
+                                 REPROC_STOP_TERMINATE, 5000,
+                                 REPROC_STOP_NOOP, 0);
+```
+
+Call `reproc_wait`, `reproc_terminate` and `reproc_kill` directly if you need
+extra logic such as logging between calls.
+
+`stop_actions` can contain up to three stop actions that instruct this function
+how the child process should be stopped. The first element of each stop action
+specifies which action should be called on the child process. The second element
+of each stop actions specifies how long to wait after executing the operation
+indicated by the first element.
+
+Note that when a stop action specifies `REPROC_STOP_WAIT`, the function will
+just wait for the specified timeout instead of performing an action to stop the
+child process.
+
+If the child process has already exited or exits during the execution of this
+function, its exit status is returned.
+
+Actionable errors:
+- `REPROC_ETIMEDOUT`
+*/
+REPROC_EXPORT int reproc_stop(reproc_t *process, reproc_stop_actions stop);
+
+/*!
+Release all resources associated with `process` including the memory allocated
+by `reproc_new`. Calling this function before a succesfull call to `reproc_wait`
+can result in resource leaks.
+
+Does not nothing if `process` is an invalid `reproc_t` instance and always
+returns an invalid `reproc_t` instance (`NULL`). By assigning the result of
+`reproc_destroy` to the instance being destroyed, it can be safely called
+multiple times on the same instance.
+
+Example: `process = reproc_destroy(process)`.
+*/
+REPROC_EXPORT reproc_t *reproc_destroy(reproc_t *process);
+
+/*!
+Returns a string describing `error`. This string must not be modified by the
+caller.
+*/
+REPROC_EXPORT const char *reproc_strerror(int error);
+
+#ifdef __cplusplus
+}
+#endif

--- a/reproc/include/reproc/run.h
+++ b/reproc/include/reproc/run.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <reproc/reproc.h>
+#include <reproc/sink.h>
+
+/*! Sets `options.redirect.parent = true` unless `discard` is set and calls
+`reproc_run_ex` with `REPROC_SINK_NULL` for the `out` and `err` sinks. */
+REPROC_EXPORT int reproc_run(const char *const *argv, reproc_options options);
+
+/*!
+Wrapper function that starts a process with the given arguments, drain its
+output and waits until it exits. Have a look at its (trivial) implementation and
+the documentation of the functions it calls to see exactly what it does:
+https://github.com/DaanDeMeyer/reproc/blob/master/reproc/src/run.c
+*/
+REPROC_EXPORT int reproc_run_ex(const char *const *argv,
+                                reproc_options options,
+                                reproc_sink out,
+                                reproc_sink err);

--- a/reproc/include/reproc/sink.h
+++ b/reproc/include/reproc/sink.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <reproc/reproc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! Used by `reproc_drain` to provide data to the caller. Each time data is
+read, `function` is called with `context` .*/
+typedef struct reproc_sink {
+  bool (*function)(REPROC_STREAM stream,
+                   const uint8_t *buffer,
+                   size_t size,
+                   void *context);
+  void *context;
+} reproc_sink;
+
+/*! Pass `REPROC_SINK_NULL` as the sink for output streams that have not been
+redirected to a pipe. */
+REPROC_EXPORT extern const reproc_sink REPROC_SINK_NULL;
+
+/*!
+Calls `reproc_read` on `stream` until `reproc_read` returns an error or one of
+the sinks returns false. The `out` and `err` sinks receive the output from
+stdout and stderr respectively. The same sink may be passed to both `out` and
+`err`.
+
+`reproc_drain` always starts by calling both sinks once with an empty buffer and
+`stream` set to `REPROC_STREAM_IN` to give each sink the chance to process all
+output from the previous call to `reproc_drain` one by one.
+
+Note that his function returns 0 instead of `REPROC_EPIPE` when both output
+streams of the child process are closed.
+
+For examples of sinks, see `sink.h`.
+
+Actionable errors:
+- `REPROC_ETIMEDOUT`
+*/
+REPROC_EXPORT int
+reproc_drain(reproc_t *process, reproc_sink out, reproc_sink err);
+
+/*!
+Stores the output (both stdout and stderr) of a process in `output`.
+
+Expects a `char **` with its value set to `NULL` as its initial context.
+(Re)Allocates memory as necessary to store the output and assigns it as the
+value of the given context. If allocating more memory fails, the already
+allocated memory is freed and the value of the given context is set to `NULL`.
+
+After calling `reproc_drain` with `reproc_sink_string`, the value of `output`
+will either point to valid memory or will be set to `NULL`. This means it is
+always safe to call `free` on `output`'s value after `reproc_drain` finishes.
+
+Because the context this function expects does not store the output size,
+`strlen` is called each time data is read to calculate the current size of the
+output. This might cause performance problems when draining processes that
+produce a lot of output.
+
+Similarly, this sink will not work on processes that have null terminators in
+their output because `strlen` is used to calculate the current output size.
+
+The `drain` example shows how to use `reproc_sink_string`.
+```
+*/
+REPROC_EXPORT reproc_sink reproc_sink_string(char **output);
+
+/*! Discards the output of a process. */
+REPROC_EXPORT reproc_sink reproc_sink_discard(void);
+
+/*! Calls `free` on `ptr` and returns `NULL`. Use this function to free memory
+allocated by `reproc_sink_string`. This avoids issues with allocating across
+module (DLL) boundaries on Windows. */
+REPROC_EXPORT void *reproc_free(void *ptr);

--- a/reproc/src/clock.h
+++ b/reproc/src/clock.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <stdint.h>
+
+int64_t reproc_now(void);

--- a/reproc/src/clock.posix.c
+++ b/reproc/src/clock.posix.c
@@ -1,0 +1,18 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "clock.h"
+
+#include "error.h"
+
+#include <assert.h>
+#include <time.h>
+
+int64_t reproc_now(void)
+{
+  struct timespec timespec = { 0 };
+
+  int r = clock_gettime(CLOCK_REALTIME, &timespec);
+  ASSERT_UNUSED(r == 0);
+
+  return timespec.tv_sec * 1000 + timespec.tv_nsec / 1000000;
+}

--- a/reproc/src/clock.win32.c
+++ b/reproc/src/clock.win32.c
@@ -1,0 +1,10 @@
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+
+#include "clock.h"
+
+#include <windows.h>
+
+int64_t reproc_now(void)
+{
+  return (int64_t) GetTickCount64();
+}

--- a/reproc/src/error.h
+++ b/reproc/src/error.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// Use this to assert inside a `PROTECT/UNPROTECT` block to avoid clang dead
+// store warnings.
+#define ASSERT_UNUSED(expression)                                              \
+  do {                                                                         \
+    (void) !(expression);                                                      \
+    assert((expression));                                                      \
+  } while (0)
+
+// Returns `r` if `expression` is false.
+#define ASSERT_RETURN(expression, r)                                           \
+  do {                                                                         \
+    if (!(expression)) {                                                       \
+      return (r);                                                              \
+    }                                                                          \
+  } while (false)
+
+#define ASSERT_EINVAL(expression) ASSERT_RETURN(expression, REPROC_EINVAL)
+
+// Returns a common representation of platform-specific errors. In practice, the
+// value of `errno` or `GetLastError` is negated and returned if `r` indicates
+// an error occurred (`r < 0` on Linux and `r == 0` on Windows).
+//
+// Returns 0 if no error occurred. If `r` has already been passed through
+// `error_unify` before, it is returned unmodified.
+int error_unify(int r);
+
+// `error_unify` but returns `success` if no error occurred.
+int error_unify_or_else(int r, int success);
+
+const char *error_string(int error);

--- a/reproc/src/error.posix.c
+++ b/reproc/src/error.posix.c
@@ -1,0 +1,43 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "error.h"
+
+#include "macro.h"
+
+#include <reproc/reproc.h>
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+const int REPROC_EINVAL = -EINVAL;
+const int REPROC_EPIPE = -EPIPE;
+const int REPROC_ETIMEDOUT = -ETIMEDOUT;
+const int REPROC_ENOMEM = -ENOMEM;
+const int REPROC_EWOULDBLOCK = -EWOULDBLOCK;
+
+int error_unify(int r)
+{
+  return error_unify_or_else(r, 0);
+}
+
+int error_unify_or_else(int r, int success)
+{
+  // if `r < -1`, `r` has been passed through this function before so we just
+  // return it as is.
+  return r < -1 ? r : r == -1 ? -errno : success;
+}
+
+enum { ERROR_STRING_MAX_SIZE = 512 };
+
+const char *error_string(int error)
+{
+  static THREAD_LOCAL char string[ERROR_STRING_MAX_SIZE];
+
+  int r = strerror_r(abs(error), string, ARRAY_SIZE(string));
+  if (r != 0) {
+    return "Failed to retrieve error string";
+  }
+
+  return string;
+}

--- a/reproc/src/error.win32.c
+++ b/reproc/src/error.win32.c
@@ -1,0 +1,85 @@
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+
+#include "error.h"
+
+#include "macro.h"
+
+#include <reproc/reproc.h>
+
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <windows.h>
+#include <winsock2.h>
+
+const int REPROC_EINVAL = -ERROR_INVALID_PARAMETER;
+const int REPROC_EPIPE = -ERROR_BROKEN_PIPE;
+const int REPROC_ETIMEDOUT = -WAIT_TIMEOUT;
+const int REPROC_ENOMEM = -ERROR_NOT_ENOUGH_MEMORY;
+const int REPROC_EWOULDBLOCK = -WSAEWOULDBLOCK;
+
+int error_unify(int r)
+{
+  return error_unify_or_else(r, 0);
+}
+
+int error_unify_or_else(int r, int success)
+{
+  assert(GetLastError() <= INT_MAX);
+
+  if (r < -1) {
+    return r;
+  }
+
+  if (r == -1) {
+    return -WSAGetLastError();
+  }
+
+  if (r == 0) {
+    return -(int) GetLastError();
+  }
+
+  return success;
+}
+
+enum { ERROR_STRING_MAX_SIZE = 512 };
+
+const char *error_string(int error)
+{
+  static wchar_t *wstring = NULL;
+  int r = 0;
+
+  wstring = malloc(sizeof(wchar_t) * ERROR_STRING_MAX_SIZE);
+  if (wstring == NULL) {
+    return "Failed to allocate memory for error string";
+  }
+
+  // We don't expect message sizes larger than the maximum possible int.
+  r = (int) FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM |
+                               FORMAT_MESSAGE_IGNORE_INSERTS,
+                           NULL, (DWORD) abs(error),
+                           MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), wstring,
+                           ERROR_STRING_MAX_SIZE, NULL);
+  if (r == 0) {
+    free(wstring);
+    return "Failed to retrieve error string";
+  }
+
+  static THREAD_LOCAL char string[ERROR_STRING_MAX_SIZE];
+
+  r = WideCharToMultiByte(CP_UTF8, 0, wstring, -1, string, ARRAY_SIZE(string),
+                          NULL, NULL);
+
+  free(wstring);
+
+  if (r == 0) {
+    return "Failed to convert error string to UTF-8";
+  }
+
+  // Remove trailing whitespace and period.
+  if (r >= 4) {
+    string[r - 4] = '\0';
+  }
+
+  return string;
+}

--- a/reproc/src/handle.h
+++ b/reproc/src/handle.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#if defined(_WIN32)
+typedef void *handle_type; // `HANDLE`
+#else
+typedef int handle_type; // fd
+#endif
+
+extern const handle_type HANDLE_INVALID; // NOLINT
+
+int handle_from(FILE *file, handle_type *handle);
+
+// Sets the `FD_CLOEXEC` flag on the file descriptor. POSIX only.
+int handle_cloexec(handle_type handle, bool enable);
+
+// Closes `handle` if it is not an invalid handle and returns an invalid handle.
+// Does not overwrite the last system error if an error occurs while closing
+// `handle`.
+handle_type handle_destroy(handle_type handle);

--- a/reproc/src/handle.posix.c
+++ b/reproc/src/handle.posix.c
@@ -1,0 +1,59 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "handle.h"
+
+#include "error.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+const int HANDLE_INVALID = -1;
+
+int handle_from(FILE *file, int *handle)
+{
+  assert(handle);
+
+  int r = fileno(file);
+  if (r < 0) {
+    return error_unify(r);
+  }
+
+  *handle = r;
+
+  return 0;
+}
+
+int handle_cloexec(int handle, bool enable)
+{
+  int r = -1;
+
+  r = fcntl(handle, F_GETFD, 0);
+  if (r < 0) {
+    return error_unify(r);
+  }
+
+  r = enable ? r | FD_CLOEXEC : r & ~FD_CLOEXEC;
+
+  r = fcntl(handle, F_SETFD, r);
+  if (r < 0) {
+    return error_unify(r);
+  }
+
+  return 0;
+}
+
+int handle_destroy(int handle)
+{
+  if (handle == HANDLE_INVALID) {
+    return HANDLE_INVALID;
+  }
+
+  int r = 0;
+
+  r = close(handle);
+  ASSERT_UNUSED(r == 0);
+
+  return HANDLE_INVALID;
+}

--- a/reproc/src/handle.win32.c
+++ b/reproc/src/handle.win32.c
@@ -1,0 +1,51 @@
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+
+#include "handle.h"
+
+#include "error.h"
+
+#include <assert.h>
+#include <io.h>
+#include <windows.h>
+
+const HANDLE HANDLE_INVALID = INVALID_HANDLE_VALUE; // NOLINT
+
+int handle_from(FILE *file, HANDLE *handle)
+{
+  int r = -1;
+
+  r = _fileno(file);
+  if (r < 0) {
+    return -ERROR_INVALID_HANDLE;
+  }
+
+  intptr_t result = _get_osfhandle(r);
+  if (result == -1) {
+    return -ERROR_INVALID_HANDLE;
+  }
+
+  *handle = (HANDLE) result;
+
+  return error_unify(r);
+}
+
+int handle_cloexec(handle_type handle, bool enable)
+{
+  (void) handle;
+  (void) enable;
+  return -ERROR_CALL_NOT_IMPLEMENTED;
+}
+
+HANDLE handle_destroy(HANDLE handle)
+{
+  if (handle == NULL || handle == HANDLE_INVALID) {
+    return HANDLE_INVALID;
+  }
+
+  int r = 0;
+
+  r = CloseHandle(handle);
+  ASSERT_UNUSED(r != 0);
+
+  return HANDLE_INVALID;
+}

--- a/reproc/src/init.h
+++ b/reproc/src/init.h
@@ -1,0 +1,5 @@
+#pragma once
+
+int init(void);
+
+void deinit(void);

--- a/reproc/src/init.posix.c
+++ b/reproc/src/init.posix.c
@@ -1,0 +1,10 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "init.h"
+
+int init(void)
+{
+  return 0;
+}
+
+void deinit(void) {}

--- a/reproc/src/init.win32.c
+++ b/reproc/src/init.win32.c
@@ -1,0 +1,25 @@
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+
+#include "init.h"
+
+#include "error.h"
+
+#include <assert.h>
+#include <winsock2.h>
+
+int init(void)
+{
+  WSADATA data;
+  int r = WSAStartup(MAKEWORD(2, 2), &data);
+  return error_unify(r);
+}
+
+void deinit(void)
+{
+  int saved = WSAGetLastError();
+
+  int r = WSACleanup();
+  ASSERT_UNUSED(r == 0);
+
+  WSASetLastError(saved);
+}

--- a/reproc/src/macro.h
+++ b/reproc/src/macro.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+#define MIN(a, b) (a) < (b) ? (a) : (b)
+
+#if defined(_WIN32) && !defined(__MINGW32__)
+  #define THREAD_LOCAL __declspec(thread)
+#else
+  #define THREAD_LOCAL __thread
+#endif

--- a/reproc/src/pipe.h
+++ b/reproc/src/pipe.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef _WIN32
+typedef uint64_t pipe_type; // `SOCKET`
+#else
+typedef int pipe_type; // fd
+#endif
+
+// Keep in sync with `REPROC_EVENT`.
+enum {
+  PIPE_EVENT_IN = 1 << 0,
+  PIPE_EVENT_OUT = 1 << 1,
+  PIPE_EVENT_ERR = 1 << 2,
+  PIPE_EVENT_EXIT = 1 << 3
+};
+
+typedef struct {
+  pipe_type in;
+  pipe_type out;
+  pipe_type err;
+  pipe_type exit;
+  int events;
+} pipe_set;
+
+enum { PIPES_PER_SET = 4 };
+
+extern const pipe_type PIPE_INVALID;
+
+// Creates a new anonymous pipe. `parent` and `child` are set to the parent and
+// child endpoint of the pipe respectively.
+int pipe_init(pipe_type *read, pipe_type *write);
+
+// Sets `pipe` to nonblocking mode.
+int pipe_nonblocking(pipe_type pipe, bool enable);
+
+// Reads up to `size` bytes into `buffer` from the pipe indicated by `pipe` and
+// returns the amount of bytes read.
+int pipe_read(pipe_type pipe, uint8_t *buffer, size_t size);
+
+// Writes up to `size` bytes from `buffer` to the pipe indicated by `pipe` and
+// returns the amount of bytes written.
+int pipe_write(pipe_type pipe, const uint8_t *buffer, size_t size);
+
+// Returns the first stream of `in`, `out` and `err` that has data available to
+// read. 0 => in, 1 => out, 2 => err.
+//
+// Returns `REPROC_EPIPE` if `in`, `out` and `err` are invalid.
+int pipe_wait(pipe_set *sets, size_t num_sets, int timeout);
+
+pipe_type pipe_destroy(pipe_type pipe);

--- a/reproc/src/pipe.posix.c
+++ b/reproc/src/pipe.posix.c
@@ -1,0 +1,153 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "pipe.h"
+
+#include "error.h"
+#include "handle.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+const int PIPE_INVALID = -1;
+
+int pipe_init(int *read, int *write)
+{
+  assert(read);
+  assert(write);
+
+  int pair[] = { PIPE_INVALID, PIPE_INVALID };
+  int r = -1;
+
+  r = pipe(pair);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = handle_cloexec(pair[0], true);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = handle_cloexec(pair[1], true);
+  if (r < 0) {
+    goto finish;
+  }
+
+  *read = pair[0];
+  *write = pair[1];
+
+  pair[0] = PIPE_INVALID;
+  pair[1] = PIPE_INVALID;
+
+finish:
+  pipe_destroy(pair[0]);
+  pipe_destroy(pair[1]);
+
+  return error_unify(r);
+}
+
+int pipe_nonblocking(int pipe, bool enable)
+{
+  int r = -1;
+
+  r = fcntl(pipe, F_GETFL, 0);
+  if (r < 0) {
+    return error_unify(r);
+  }
+
+  r = enable ? r | O_NONBLOCK : r & ~O_NONBLOCK;
+
+  r = fcntl(pipe, F_SETFL, r);
+
+  return error_unify(r);
+}
+
+int pipe_read(int pipe, uint8_t *buffer, size_t size)
+{
+  assert(pipe != PIPE_INVALID);
+  assert(buffer);
+
+  int r = (int) read(pipe, buffer, size);
+
+  if (r == 0) {
+    // `read` returns 0 to indicate the other end of the pipe was closed.
+    r = -EPIPE;
+  }
+
+  return error_unify_or_else(r, r);
+}
+
+int pipe_write(int pipe, const uint8_t *buffer, size_t size)
+{
+  assert(pipe != PIPE_INVALID);
+  assert(buffer);
+
+  int r = (int) write(pipe, buffer, size);
+
+  return error_unify_or_else(r, r);
+}
+
+int pipe_wait(pipe_set *sets, size_t num_sets, int timeout)
+{
+  assert(num_sets * PIPES_PER_SET <= INT_MAX);
+
+  struct pollfd *pollfds = NULL;
+  size_t num_pipes = num_sets * PIPES_PER_SET;
+  int r = -ENOMEM;
+
+  pollfds = calloc(sizeof(struct pollfd), num_pipes);
+  if (pollfds == NULL) {
+    goto finish;
+  }
+
+  for (size_t i = 0; i < num_sets; i++) {
+    size_t j = i * PIPES_PER_SET;
+    pollfds[j + 0] = (struct pollfd){ .fd = sets[i].in, .events = POLLOUT };
+    pollfds[j + 1] = (struct pollfd){ .fd = sets[i].out, .events = POLLIN };
+    pollfds[j + 2] = (struct pollfd){ .fd = sets[i].err, .events = POLLIN };
+    // macos 10.15 indicates `POLLIN` instead of `POLLHUP` when the peer fd is
+    // closed.
+    pollfds[j + 3] = (struct pollfd){ .fd = sets[i].exit, .events = POLLIN };
+  }
+
+  r = poll(pollfds, (nfds_t) num_pipes, timeout);
+  if (r < 0) {
+    goto finish;
+  }
+
+  for (size_t i = 0; i < num_sets; i++) {
+    sets[i].events = 0;
+  }
+
+  for (size_t i = 0; i < num_pipes; i++) {
+    struct pollfd pollfd = pollfds[i];
+
+    if (pollfd.revents > 0) {
+      int event = 1 << (i % PIPES_PER_SET);
+      sets[i / PIPES_PER_SET].events |= event;
+    }
+  }
+
+  if (r == 0) {
+    r = -ETIMEDOUT;
+  } else if (r > 0) {
+    // `poll` returns the amount of ready file descriptors on success so we
+    // explicitly reset `r` to 0.
+    r = 0;
+  }
+
+finish:
+  free(pollfds);
+
+  return r;
+}
+
+int pipe_destroy(int pipe)
+{
+  return handle_destroy(pipe);
+}

--- a/reproc/src/pipe.win32.c
+++ b/reproc/src/pipe.win32.c
@@ -1,0 +1,249 @@
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+
+#include "pipe.h"
+
+#include "error.h"
+#include "handle.h"
+#include "macro.h"
+
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <windows.h>
+#include <winsock2.h>
+
+const SOCKET PIPE_INVALID = INVALID_SOCKET;
+
+// Inspired by https://gist.github.com/geertj/4325783.
+static int socketpair(int domain, int type, int protocol, SOCKET *out)
+{
+  assert(out);
+
+  SOCKET server = PIPE_INVALID;
+  SOCKET pair[] = { PIPE_INVALID, PIPE_INVALID };
+  int r = -1;
+
+  server = WSASocketW(AF_INET, SOCK_STREAM, 0, NULL, 0, 0);
+  if (server == INVALID_SOCKET) {
+    goto finish;
+  }
+
+  SOCKADDR_IN localhost = { 0 };
+  localhost.sin_family = AF_INET;
+  localhost.sin_addr.S_un.S_addr = htonl(INADDR_LOOPBACK);
+  localhost.sin_port = 0;
+
+  r = bind(server, (SOCKADDR *) &localhost, sizeof(localhost));
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = listen(server, 1);
+  if (r < 0) {
+    goto finish;
+  }
+
+  SOCKADDR_STORAGE name = { 0 };
+  int size = sizeof(name);
+  r = getsockname(server, (SOCKADDR *) &name, &size);
+  if (r < 0) {
+    goto finish;
+  }
+
+  pair[0] = WSASocketW(domain, type, protocol, NULL, 0, 0);
+  if (pair[0] == INVALID_SOCKET) {
+    goto finish;
+  }
+
+  r = pipe_nonblocking(pair[0], true);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = connect(pair[0], (SOCKADDR *) &name, size);
+  if (r < 0 && WSAGetLastError() != WSAEWOULDBLOCK) {
+    goto finish;
+  }
+
+  r = pipe_nonblocking(pair[0], false);
+  if (r < 0) {
+    goto finish;
+  }
+
+  pair[1] = accept(server, NULL, NULL);
+  if (pair[1] == INVALID_SOCKET) {
+    r = -1;
+    goto finish;
+  }
+
+  out[0] = pair[0];
+  out[1] = pair[1];
+
+  pair[0] = PIPE_INVALID;
+  pair[1] = PIPE_INVALID;
+
+  r = 0;
+
+finish:
+  pipe_destroy(server);
+  pipe_destroy(pair[0]);
+  pipe_destroy(pair[1]);
+
+  return error_unify(r);
+}
+
+int pipe_init(SOCKET *read, SOCKET *write)
+{
+  assert(read);
+  assert(write);
+
+  SOCKET pair[] = { PIPE_INVALID, PIPE_INVALID };
+  int r = 0;
+
+  // Use sockets instead of pipes so we can use `WSAPoll` which only works with
+  // sockets.
+  r = socketpair(AF_INET, SOCK_STREAM, 0, pair);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = SetHandleInformation((HANDLE) pair[0], HANDLE_FLAG_INHERIT, 0);
+  if (r == 0) {
+    goto finish;
+  }
+
+  r = SetHandleInformation((HANDLE) pair[1], HANDLE_FLAG_INHERIT, 0);
+  if (r == 0) {
+    goto finish;
+  }
+
+  // Make the connection unidirectional to better emulate a pipe.
+
+  r = shutdown(pair[0], SD_SEND);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = shutdown(pair[1], SD_RECEIVE);
+  if (r < 0) {
+    goto finish;
+  }
+
+  *read = pair[0];
+  *write = pair[1];
+
+  pair[0] = PIPE_INVALID;
+  pair[1] = PIPE_INVALID;
+
+finish:
+  pipe_destroy(pair[0]);
+  pipe_destroy(pair[1]);
+
+  return error_unify(r);
+}
+
+int pipe_nonblocking(SOCKET pipe, bool enable)
+{
+  u_long mode = enable;
+  int r = ioctlsocket(pipe, (long) FIONBIO, &mode);
+  return error_unify(r);
+}
+
+int pipe_read(SOCKET pipe, uint8_t *buffer, size_t size)
+{
+  assert(pipe != PIPE_INVALID);
+  assert(buffer);
+  assert(size <= INT_MAX);
+
+  int r = recv(pipe, (char *) buffer, (int) size, 0);
+
+  if (r == 0 || (r < 0 && WSAGetLastError() == WSAECONNRESET)) {
+    r = -ERROR_BROKEN_PIPE;
+  }
+
+  return error_unify_or_else(r, r);
+}
+
+int pipe_write(SOCKET pipe, const uint8_t *buffer, size_t size)
+{
+  assert(pipe != PIPE_INVALID);
+  assert(buffer);
+  assert(size <= INT_MAX);
+
+  int r = send(pipe, (const char *) buffer, (int) size, 0);
+
+  if (r < 0 && WSAGetLastError() == WSAECONNRESET) {
+    r = -ERROR_BROKEN_PIPE;
+  }
+
+  return error_unify_or_else(r, r);
+}
+
+int pipe_wait(pipe_set *sets, size_t num_sets, int timeout)
+{
+  assert(num_sets * PIPES_PER_SET <= INT_MAX);
+
+  WSAPOLLFD *pollfds = NULL;
+  size_t num_pipes = num_sets * PIPES_PER_SET;
+  int r = -ERROR_NOT_ENOUGH_MEMORY;
+
+  pollfds = calloc(sizeof(WSAPOLLFD), num_pipes);
+  if (pollfds == NULL) {
+    goto finish;
+  }
+
+  for (size_t i = 0; i < num_sets; i++) {
+    size_t j = i * PIPES_PER_SET;
+    pollfds[j + 0] = (WSAPOLLFD){ .fd = sets[i].in, .events = POLLOUT };
+    pollfds[j + 1] = (WSAPOLLFD){ .fd = sets[i].out, .events = POLLIN };
+    pollfds[j + 2] = (WSAPOLLFD){ .fd = sets[i].err, .events = POLLIN };
+    pollfds[j + 3] = (WSAPOLLFD){ .fd = sets[i].exit };
+  }
+
+  r = WSAPoll(pollfds, (ULONG) num_pipes, timeout);
+  if (r < 0) {
+    goto finish;
+  }
+
+  for (size_t i = 0; i < num_sets; i++) {
+    sets[i].events = 0;
+  }
+
+  for (size_t i = 0; i < num_pipes; i++) {
+    WSAPOLLFD pollfd = pollfds[i];
+
+    if (pollfd.revents > 0 && pollfd.revents != POLLNVAL) {
+      int event = 1 << (i % PIPES_PER_SET);
+      sets[i / PIPES_PER_SET].events |= event;
+    }
+  }
+
+  if (r == 0) {
+    r = -WAIT_TIMEOUT;
+  } else if(r > 0) {
+    // `WSAPoll` returns the amount of ready sockets on success so we explicitly
+    // reset `r` to 0.
+    r = 0;
+  }
+
+finish:
+  free(pollfds);
+
+  return r;
+}
+
+SOCKET pipe_destroy(SOCKET pipe)
+{
+  if (pipe == PIPE_INVALID) {
+    return PIPE_INVALID;
+  }
+
+  int saved = WSAGetLastError();
+
+  int r = closesocket(pipe);
+  ASSERT_UNUSED(r == 0);
+
+  WSASetLastError(saved);
+
+  return PIPE_INVALID;
+}

--- a/reproc/src/process.h
+++ b/reproc/src/process.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "handle.h"
+
+#include <stdbool.h>
+
+#if defined(_WIN32)
+typedef void *process_type; // `HANDLE`
+#else
+typedef int process_type; // `pid_t`
+#endif
+
+extern const process_type PROCESS_INVALID; // NOLINT
+
+struct process_options {
+  // If `NULL`, the child process inherits the environment of the current
+  // process.
+  const char *const *environment;
+  // If not `NULL`, the working directory of the child process is set to
+  // `working_directory`.
+  const char *working_directory;
+  // The standard streams of the child process are redirected to the `in`, `out`
+  // and `err` handles. If a handle is `HANDLE_INVALID`, the corresponding child
+  // process standard stream is closed. The `exit` handle is simply inherited by
+  // the child process.
+  struct {
+    handle_type in;
+    handle_type out;
+    handle_type err;
+    handle_type exit;
+  } handle;
+};
+
+// Spawns a child process that executes the command stored in `argv`.
+//
+// If `argv` is `NULL` on POSIX, `exec` is not called after fork and this
+// function returns 0 in the child process and > 0 in the parent process. On
+// Windows, if `argv` is `NULL`, an error is returned.
+//
+// The process handle of the new child process is assigned to `process`.
+int process_start(process_type *process,
+                  const char *const *argv,
+                  struct process_options options);
+
+// Returns the process's exit status if it has finished running.
+int process_wait(process_type process);
+
+// Sends the `SIGTERM` (POSIX) or `CTRL-BREAK` (Windows) signal to the process
+// indicated by `process`.
+int process_terminate(process_type process);
+
+// Sends the `SIGKILL` signal to `process` (POSIX) or calls `TerminateProcess`
+// on `process` (Windows).
+int process_kill(process_type process);
+
+process_type process_destroy(process_type process);

--- a/reproc/src/process.posix.c
+++ b/reproc/src/process.posix.c
@@ -1,0 +1,479 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "process.h"
+
+#include "error.h"
+#include "macro.h"
+#include "pipe.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+const pid_t PROCESS_INVALID = -1;
+
+static int signal_mask(int how, const sigset_t *newmask, sigset_t *oldmask)
+{
+  int r = -1;
+
+#if defined(REPROC_MULTITHREADED)
+  // `pthread_sigmask` returns positive errno values so we negate them.
+  r = -pthread_sigmask(how, newmask, oldmask);
+#else
+  r = sigprocmask(how, newmask, oldmask);
+#endif
+
+  return error_unify(r);
+}
+
+// Returns true if the null-terminated string indicated by `path` is a relative
+// path. A path is relative if any character except the first is a forward slash
+// ('/').
+static bool path_is_relative(const char *path)
+{
+  return strlen(path) > 0 && path[0] != '/' && strchr(path + 1, '/') != NULL;
+}
+
+// Prepends the null-terminated string indicated by `path` with the current
+// working directory. The caller is responsible for freeing the result of this
+// function. If an error occurs, `NULL` is returned and `errno` is set to
+// indicate the error.
+static char *path_prepend_cwd(const char *path)
+{
+  assert(path);
+
+  size_t path_size = strlen(path);
+  size_t cwd_size = PATH_MAX;
+
+  // We always allocate sufficient space for `path` but do not include this
+  // space in `cwd_size` so we can be sure that when `getcwd` succeeds there is
+  // sufficient space left in `cwd` to append `path`.
+
+  // +2 reserves space to add a null terminator and potentially a missing '/'
+  // after the current working directory.
+  char *cwd = calloc(cwd_size + path_size + 2, sizeof(char));
+  if (cwd == NULL) {
+    return cwd;
+  }
+
+  while (getcwd(cwd, cwd_size) == NULL) {
+    if (errno != ERANGE) {
+      free(cwd);
+      return NULL;
+    }
+
+    cwd_size += PATH_MAX;
+
+    char *result = realloc(cwd, cwd_size + path_size + 1);
+    if (result == NULL) {
+      free(cwd);
+      return result;
+    }
+
+    cwd = result;
+  }
+
+  cwd_size = strlen(cwd);
+
+  // Add a forward slash after `cwd` if there is none.
+  if (cwd[cwd_size - 1] != '/') {
+    cwd[cwd_size] = '/';
+    cwd[cwd_size + 1] = '\0';
+    cwd_size++;
+  }
+
+  // We've made sure there's sufficient space left in `cwd` to add `path` and a
+  // null terminator.
+  memcpy(cwd + cwd_size, path, path_size);
+  cwd[cwd_size + path_size] = '\0';
+
+  return cwd;
+}
+
+static const int MAX_FD_LIMIT = 1024 * 1024;
+
+static int get_max_fd(void)
+{
+  struct rlimit limit = { 0 };
+
+  int r = getrlimit(RLIMIT_NOFILE, &limit);
+  if (r < 0) {
+    return error_unify(r);
+  }
+
+  rlim_t soft = limit.rlim_cur;
+
+  if (soft == RLIM_INFINITY || soft > INT_MAX) {
+    return INT_MAX;
+  }
+
+  return (int) (soft - 1);
+}
+
+static bool fd_in_set(int fd, const int *fd_set, size_t size)
+{
+  for (size_t i = 0; i < size; i++) {
+    if (fd == fd_set[i]) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static pid_t process_fork(const int *except, size_t num_except)
+{
+  struct {
+    sigset_t old;
+    sigset_t new;
+  } mask;
+
+  int r = -1;
+
+  // We don't want signal handlers of the parent to run in the child process so
+  // we block all signals before forking.
+
+  r = sigfillset(&mask.new);
+  if (r < 0) {
+    return error_unify(r);
+  }
+
+  r = signal_mask(SIG_SETMASK, &mask.new, &mask.old);
+  if (r < 0) {
+    return error_unify(r);
+  }
+
+  struct {
+    int read;
+    int write;
+  } pipe = { PIPE_INVALID, PIPE_INVALID };
+
+  r = pipe_init(&pipe.read, &pipe.write);
+  if (r < 0) {
+    return error_unify(r);
+  }
+
+  r = fork();
+  if (r < 0) {
+    // `fork` error.
+
+    r = signal_mask(SIG_SETMASK, &mask.new, &mask.old);
+    ASSERT_UNUSED(r == 0);
+
+    pipe_destroy(pipe.read);
+    pipe_destroy(pipe.write);
+
+    return error_unify(r);
+  }
+
+  if (r > 0) {
+    // Parent process
+
+    pid_t child = r;
+
+    // From now on, the child process might have started so we don't report
+    // errors from `signal_mask` and `read`. This puts the responsibility
+    // for cleaning up the process in the hands of the caller.
+
+    r = signal_mask(SIG_SETMASK, &mask.old, &mask.old);
+    ASSERT_UNUSED(r == 0);
+
+    // Close the error pipe write end on the parent's side so `read` will return
+    // when it is closed on the child side as well.
+    pipe_destroy(pipe.write);
+
+    int child_errno = 0;
+    r = (int) read(pipe.read, &child_errno, sizeof(child_errno));
+    ASSERT_UNUSED(r >= 0);
+
+    if (child_errno > 0) {
+      // If the child writes to the error pipe and exits, we're certain the
+      // child process exited on its own and we can report errors as usual.
+      r = waitpid(child, NULL, 0);
+      assert(r < 0 || r == child);
+
+      if (r == child) {
+        r = -child_errno;
+      }
+    } else {
+      r = 0;
+    }
+
+    pipe_destroy(pipe.read);
+
+    return error_unify_or_else(r, child);
+  }
+
+  // Child process
+
+  // Reset all signal handlers so they don't run in the child process. By
+  // default, a child process inherits the parent's signal handlers but we
+  // override this as most signal handlers won't be written in a way that they
+  // can deal with being run in a child process.
+
+  struct sigaction action = { .sa_handler = SIG_DFL };
+
+  r = sigemptyset(&action.sa_mask);
+  if (r < 0) {
+    goto finish;
+  }
+
+  // NSIG is not standardized so we use a fixed limit instead.
+  for (int signal = 0; signal < 32; signal++) {
+    r = sigaction(signal, &action, NULL);
+    if (r < 0 && errno != EINVAL) {
+      goto finish;
+    }
+  }
+
+  // Reset the child's signal mask to the default signal mask. By default, a
+  // child process inherits the parent's signal mask (even over an `exec` call)
+  // but we override this as most processes won't be written in a way that they
+  // can deal with starting with a custom signal mask.
+
+  r = sigemptyset(&mask.new);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = signal_mask(SIG_SETMASK, &mask.new, NULL);
+  if (r < 0) {
+    goto finish;
+  }
+
+  // Not all file descriptors might have been created with the `FD_CLOEXEC`
+  // flag so we manually close all file descriptors to prevent file descriptors
+  // leaking into the child process.
+
+  int max_fd = get_max_fd();
+  if (max_fd < 0) {
+    goto finish;
+  }
+
+  if (max_fd > MAX_FD_LIMIT) {
+    // Refuse to try to close too many file descriptors.
+    r = -EMFILE;
+    goto finish;
+  }
+
+  for (int i = 0; i < max_fd; i++) {
+    // Make sure we don't close the error pipe file descriptors twice.
+    if (i == pipe.read || i == pipe.write) {
+      continue;
+    }
+
+    if (fd_in_set(i, except, num_except)) {
+      continue;
+    }
+
+    // Check if `i` is a valid file descriptor before trying to close it.
+    r = fcntl(i, F_GETFD);
+    if (r >= 0) {
+      handle_destroy(i);
+    }
+  }
+
+  r = 0;
+
+finish:
+  if (r < 0) {
+    (void) !write(pipe.write, &errno, sizeof(errno));
+    _exit(EXIT_FAILURE);
+  }
+
+  pipe_destroy(pipe.write);
+  pipe_destroy(pipe.read);
+
+  return 0;
+}
+
+int process_start(pid_t *process,
+                  const char *const *argv,
+                  struct process_options options)
+{
+  assert(process);
+
+  if (argv != NULL) {
+    assert(argv[0] != NULL);
+  }
+
+  struct {
+    int read;
+    int write;
+  } pipe = { PIPE_INVALID, PIPE_INVALID };
+  char *program = NULL;
+  int r = -1;
+
+  // We create an error pipe to receive errors from the child process.
+  r = pipe_init(&pipe.read, &pipe.write);
+  if (r < 0) {
+    goto finish;
+  }
+
+  if (argv != NULL) {
+    // We prepend the parent working directory to `program` if it is a
+    // relative path so that it will always be searched for relative to the
+    // parent working directory even after executing `chdir`.
+    program = options.working_directory && path_is_relative(argv[0])
+                  ? path_prepend_cwd(argv[0])
+                  : strdup(argv[0]);
+    if (program == NULL) {
+      r = -1;
+      goto finish;
+    }
+  }
+
+  int except[] = { options.handle.in, options.handle.out, options.handle.err,
+                   pipe.read,         pipe.write,         options.handle.exit };
+
+  r = process_fork(except, ARRAY_SIZE(except));
+  if (r < 0) {
+    goto finish;
+  }
+
+  if (r == 0) {
+    // Redirect stdin, stdout and stderr.
+
+    int redirect[] = { options.handle.in, options.handle.out,
+                       options.handle.err };
+
+    for (int i = 0; i < (int) ARRAY_SIZE(redirect); i++) {
+      // `i` corresponds to the standard stream we need to redirect.
+      r = dup2(redirect[i], i);
+      if (r < 0) {
+        goto child;
+      }
+
+      // Make sure we don't accidentally cloexec the standard streams of the
+      // child process when we're inheriting the parent standard streams.
+      if (redirect[i] != i) {
+        // Make sure the pipe is closed when we call exec.
+        r = handle_cloexec(redirect[i], true);
+        if (r < 0) {
+          goto child;
+        }
+      }
+    }
+
+    // Make sure the `exit` file descriptor is inherited.
+
+    r = handle_cloexec(options.handle.exit, false);
+    if (r < 0) {
+      goto child;
+    }
+
+    if (options.working_directory != NULL) {
+      r = chdir(options.working_directory);
+      if (r < 0) {
+        goto child;
+      }
+    }
+
+    if (options.environment != NULL) {
+      // `environ` is carried over calls to `exec`.
+      extern char **environ; // NOLINT
+      environ = (char **) options.environment;
+    }
+
+    if (argv != NULL) {
+      assert(program);
+
+      r = execvp(program, (char *const *) argv);
+      if (r < 0) {
+        goto child;
+      }
+    }
+
+  child:
+    if (r < 0) {
+      (void) !write(pipe.write, &errno, sizeof(errno));
+      _exit(EXIT_FAILURE);
+    }
+
+    pipe_destroy(pipe.read);
+    pipe_destroy(pipe.write);
+    free(program);
+
+    return 0;
+  }
+
+  pid_t child = r;
+
+  // Close the error pipe write end on the parent's side so `read` will return
+  // when it is closed on the child side as well.
+  pipe.write = pipe_destroy(pipe.write);
+
+  int child_errno = 0;
+  r = (int) read(pipe.read, &child_errno, sizeof(child_errno));
+  ASSERT_UNUSED(r >= 0);
+
+  if (child_errno > 0) {
+    r = waitpid(child, NULL, 0);
+    if (r == child) {
+      r = -child_errno;
+    }
+
+    goto finish;
+  } else {
+    r = 0;
+  }
+
+  *process = child;
+
+finish:
+  pipe_destroy(pipe.read);
+  pipe_destroy(pipe.write);
+  free(program);
+
+  return error_unify_or_else(r, 1);
+}
+
+static int parse_status(int status)
+{
+  return WIFEXITED(status) ? WEXITSTATUS(status) : WTERMSIG(status) + UINT8_MAX;
+}
+
+int process_wait(pid_t process)
+{
+  assert(process != PROCESS_INVALID);
+
+  int status = 0;
+  int r = waitpid(process, &status, 0);
+  if (r < 0) {
+    return error_unify(r);
+  }
+
+  assert(r == process);
+
+  return parse_status(status);
+}
+
+int process_terminate(pid_t process)
+{
+  assert(process != PROCESS_INVALID);
+
+  int r = kill(process, SIGTERM);
+  return error_unify(r);
+}
+
+int process_kill(pid_t process)
+{
+  assert(process != PROCESS_INVALID);
+
+  int r = kill(process, SIGKILL);
+  return error_unify(r);
+}
+
+pid_t process_destroy(pid_t process)
+{
+  // `waitpid` already cleans up the process for us.
+  (void) process;
+  return PROCESS_INVALID;
+}

--- a/reproc/src/process.win32.c
+++ b/reproc/src/process.win32.c
@@ -1,0 +1,469 @@
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+
+#include "process.h"
+
+#include "error.h"
+#include "macro.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <windows.h>
+
+const HANDLE PROCESS_INVALID = INVALID_HANDLE_VALUE; // NOLINT
+
+extern const int REPROC_SIGKILL;
+extern const int REPROC_SIGTERM;
+
+static const DWORD CREATION_FLAGS =
+    // Create each child process in a new process group so we don't send
+    // `CTRL-BREAK` signals to more than one child process in
+    // `process_terminate`.
+    CREATE_NEW_PROCESS_GROUP |
+    // Create each child process with a Unicode environment as we accept any
+    // UTF-16 encoded environment (including Unicode characters). Create each
+    CREATE_UNICODE_ENVIRONMENT |
+    // Create each child with an extended STARTUPINFOEXW structure so we can
+    // specify which handles should be inherited.
+    EXTENDED_STARTUPINFO_PRESENT;
+
+static SECURITY_ATTRIBUTES HANDLE_DO_NOT_INHERIT = {
+  .nLength = sizeof(SECURITY_ATTRIBUTES),
+  .bInheritHandle = false,
+  .lpSecurityDescriptor = NULL
+};
+
+// Argument escaping implementation is based on the following blog post:
+// https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+
+static bool argument_should_escape(const char *argument)
+{
+  assert(argument);
+
+  bool should_escape = false;
+
+  for (size_t i = 0; i < strlen(argument); i++) {
+    should_escape = should_escape || argument[i] == ' ' ||
+                    argument[i] == '\t' || argument[i] == '\n' ||
+                    argument[i] == '\v' || argument[i] == '\"';
+  }
+
+  return should_escape;
+}
+
+static size_t argument_escaped_size(const char *argument)
+{
+  assert(argument);
+
+  size_t argument_size = strlen(argument);
+
+  if (!argument_should_escape(argument)) {
+    return argument_size;
+  }
+
+  size_t size = 2; // double quotes
+
+  for (size_t i = 0; i < argument_size; i++) {
+    size_t num_backslashes = 0;
+
+    while (i < argument_size && argument[i] == '\\') {
+      i++;
+      num_backslashes++;
+    }
+
+    if (i == argument_size) {
+      size += num_backslashes * 2;
+    } else if (argument[i] == '"') {
+      size += num_backslashes * 2 + 2;
+    } else {
+      size += num_backslashes + 1;
+    }
+  }
+
+  return size;
+}
+
+static size_t argument_escape(char *dest, const char *argument)
+{
+  assert(dest);
+  assert(argument);
+
+  size_t argument_size = strlen(argument);
+
+  if (!argument_should_escape(argument)) {
+    memcpy(dest, argument, argument_size);
+    return argument_size;
+  }
+
+  const char *begin = dest;
+
+  *dest++ = '"';
+
+  for (size_t i = 0; i < argument_size; i++) {
+    size_t num_backslashes = 0;
+
+    while (i < argument_size && argument[i] == '\\') {
+      i++;
+      num_backslashes++;
+    }
+
+    if (i == argument_size) {
+      memset(dest, '\\', num_backslashes * 2);
+      dest += num_backslashes * 2;
+    } else if (argument[i] == '"') {
+      memset(dest, '\\', num_backslashes * 2 + 1);
+      dest += num_backslashes * 2 + 1;
+      *dest++ = '"';
+    } else {
+      memset(dest, '\\', num_backslashes);
+      dest += num_backslashes;
+      *dest++ = argument[i];
+    }
+  }
+
+  *dest++ = '"';
+
+  return (size_t)(dest - begin);
+}
+
+static char *argv_join(const char *const *argv)
+{
+  assert(argv);
+
+  // Determine the size of the concatenated string first.
+  size_t joined_size = 1; // Count the null terminator.
+  for (int i = 0; argv[i] != NULL; i++) {
+    joined_size += argument_escaped_size(argv[i]);
+
+    if (argv[i + 1] != NULL) {
+      joined_size++; // Count whitespace.
+    }
+  }
+
+  char *joined = calloc(joined_size, sizeof(char));
+  if (joined == NULL) {
+    SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+    return NULL;
+  }
+
+  char *current = joined;
+  for (int i = 0; argv[i] != NULL; i++) {
+    current += argument_escape(current, argv[i]);
+
+    // We add a space after each argument in the joined arguments string except
+    // for the final argument.
+    if (argv[i + 1] != NULL) {
+      *current++ = ' ';
+    }
+  }
+
+  *current = '\0';
+
+  return joined;
+}
+
+static size_t environment_join_size(const char *const *environment)
+{
+  assert(environment);
+
+  size_t joined_size = 1; // Count the null terminator.
+  for (int i = 0; environment[i] != NULL; i++) {
+    joined_size += strlen(environment[i]) + 1; // Count the null terminator.
+  }
+
+  return joined_size;
+}
+
+static char *environment_join(const char *const *environment)
+{
+  assert(environment);
+
+  char *joined = calloc(environment_join_size(environment), sizeof(char));
+  if (joined == NULL) {
+    SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+    return NULL;
+  }
+
+  char *current = joined;
+  for (int i = 0; environment[i] != NULL; i++) {
+    size_t to_copy = strlen(environment[i]) + 1; // Include null terminator.
+    memcpy(current, environment[i], to_copy);
+    current += to_copy;
+  }
+
+  *current = '\0';
+
+  return joined;
+}
+
+static wchar_t *string_to_wstring(const char *string, size_t size)
+{
+  assert(string);
+  // Overflow check although we really don't expect this to ever happen. This
+  // makes the following casts to `int` safe.
+  assert(size <= INT_MAX);
+
+  // Determine wstring size (`MultiByteToWideChar` returns the required size if
+  // its last two arguments are `NULL` and 0).
+  int r = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, string, (int) size,
+                              NULL, 0);
+  if (r == 0) {
+    return NULL;
+  }
+
+  // `MultiByteToWideChar` does not return negative values so the cast to
+  // `size_t` is safe.
+  wchar_t *wstring = calloc((size_t) r, sizeof(wchar_t));
+  if (wstring == NULL) {
+    SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+    return NULL;
+  }
+
+  // Now we pass our allocated string and its size as the last two arguments
+  // instead of `NULL` and 0 which makes `MultiByteToWideChar` actually perform
+  // the conversion.
+  r = MultiByteToWideChar(CP_UTF8, 0, string, (int) size, wstring, r);
+  if (r == 0) {
+    free(wstring);
+    return NULL;
+  }
+
+  return wstring;
+}
+
+static const DWORD NUM_ATTRIBUTES = 1;
+
+static LPPROC_THREAD_ATTRIBUTE_LIST setup_attribute_list(HANDLE *handles,
+                                                         size_t num_handles)
+{
+  assert(handles);
+
+  int r = 0;
+
+  // Make sure all the given handles can be inherited.
+  for (size_t i = 0; i < num_handles; i++) {
+    r = SetHandleInformation(handles[i], HANDLE_FLAG_INHERIT,
+                             HANDLE_FLAG_INHERIT);
+    if (r == 0) {
+      return NULL;
+    }
+  }
+
+  // Get the required size for `attribute_list`.
+  SIZE_T attribute_list_size = 0;
+  r = InitializeProcThreadAttributeList(NULL, NUM_ATTRIBUTES, 0,
+                                        &attribute_list_size);
+  if (r == 0 && GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+    return NULL;
+  }
+
+  LPPROC_THREAD_ATTRIBUTE_LIST attribute_list = malloc(attribute_list_size);
+  if (attribute_list == NULL) {
+    SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+    return NULL;
+  }
+
+  r = InitializeProcThreadAttributeList(attribute_list, NUM_ATTRIBUTES, 0,
+                                        &attribute_list_size);
+  if (r == 0) {
+    free(attribute_list);
+    return NULL;
+  }
+
+  // Add the handles to be inherited to `attribute_list`.
+  r = UpdateProcThreadAttribute(attribute_list, 0,
+                                PROC_THREAD_ATTRIBUTE_HANDLE_LIST, handles,
+                                num_handles * sizeof(HANDLE), NULL, NULL);
+  if (r == 0) {
+    DeleteProcThreadAttributeList(attribute_list);
+    return NULL;
+  }
+
+  return attribute_list;
+}
+
+int process_start(HANDLE *process,
+                  const char *const *argv,
+                  struct process_options options)
+{
+  assert(process);
+
+  if (argv == NULL) {
+    return -ERROR_CALL_NOT_IMPLEMENTED;
+  }
+
+  assert(argv[0] != NULL);
+
+  char *command_line = NULL;
+  wchar_t *command_line_wstring = NULL;
+  char *environment_line = NULL;
+  wchar_t *environment_line_wstring = NULL;
+  wchar_t *working_directory_wstring = NULL;
+  LPPROC_THREAD_ATTRIBUTE_LIST attribute_list = NULL;
+  PROCESS_INFORMATION info = { PROCESS_INVALID, HANDLE_INVALID, 0, 0 };
+  int r = 0;
+
+  // Join `argv` to a whitespace delimited string as required by
+  // `CreateProcessW`.
+  command_line = argv_join(argv);
+  if (command_line == NULL) {
+    goto finish;
+  }
+
+  // Convert UTF-8 to UTF-16 as required by `CreateProcessW`.
+  command_line_wstring = string_to_wstring(command_line,
+                                           strlen(command_line) + 1);
+  if (command_line_wstring == NULL) {
+    goto finish;
+  }
+
+  // Idem for `environment` if it isn't `NULL`.
+  if (options.environment != NULL) {
+    environment_line = environment_join(options.environment);
+    if (environment_line == NULL) {
+      goto finish;
+    }
+
+    size_t joined_size = environment_join_size(options.environment);
+    environment_line_wstring = string_to_wstring(environment_line, joined_size);
+    if (environment_line_wstring == NULL) {
+      goto finish;
+    }
+  }
+
+  // Idem for `working_directory` if it isn't `NULL`.
+  if (options.working_directory != NULL) {
+    size_t working_directory_size = strlen(options.working_directory) + 1;
+    working_directory_wstring = string_to_wstring(options.working_directory,
+                                                  working_directory_size);
+    if (working_directory_wstring == NULL) {
+      goto finish;
+    }
+  }
+
+  // Windows Vista added the `STARTUPINFOEXW` structure in which we can put a
+  // list of handles that should be inherited. Only these handles are inherited
+  // by the child process. Other code in an application that calls
+  // `CreateProcess` without passing a `STARTUPINFOEXW` struct containing the
+  // handles it should inherit can still unintentionally inherit handles meant
+  // for a reproc child process. See https://stackoverflow.com/a/2345126 for
+  // more information.
+  HANDLE handles[] = { options.handle.exit, options.handle.in, options.handle.out,
+                       options.handle.err };
+  size_t num_handles = ARRAY_SIZE(handles);
+
+  if (options.handle.out == options.handle.err) {
+    // CreateProcess doesn't like the same handle being specified twice in the
+    // `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` attribute.
+    num_handles--;
+  }
+
+  attribute_list = setup_attribute_list(handles, num_handles);
+  if (attribute_list == NULL) {
+    goto finish;
+  }
+
+  STARTUPINFOEXW extended_startup_info = {
+    .StartupInfo = { .cb = sizeof(extended_startup_info),
+                     .dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW,
+                     // `STARTF_USESTDHANDLES`
+                     .hStdInput = options.handle.in,
+                     .hStdOutput = options.handle.out,
+                     .hStdError = options.handle.err,
+                     // `STARTF_USESHOWWINDOW`. Make sure the console window of
+                     // the child process isn't visible. See
+                     // https://github.com/DaanDeMeyer/reproc/issues/6 and
+                     // https://github.com/DaanDeMeyer/reproc/pull/7 for more
+                     // information.
+                     .wShowWindow = SW_HIDE },
+    .lpAttributeList = attribute_list
+  };
+
+  LPSTARTUPINFOW startup_info_address = &extended_startup_info.StartupInfo;
+
+  // Child processes inherit the error mode of their parents. To avoid child
+  // processes creating error dialogs we set our error mode to not create error
+  // dialogs temporarily which is inherited by the child process.
+  DWORD previous_error_mode = SetErrorMode(SEM_NOGPFAULTERRORBOX);
+
+  r = CreateProcessW(NULL, command_line_wstring, &HANDLE_DO_NOT_INHERIT,
+                     &HANDLE_DO_NOT_INHERIT, true, CREATION_FLAGS,
+                     environment_line_wstring, working_directory_wstring,
+                     startup_info_address, &info);
+
+  SetErrorMode(previous_error_mode);
+
+  if (r == 0) {
+    goto finish;
+  }
+
+  *process = info.hProcess;
+
+finish:
+  free(command_line);
+  free(command_line_wstring);
+  free(environment_line);
+  free(environment_line_wstring);
+  free(working_directory_wstring);
+  DeleteProcThreadAttributeList(attribute_list);
+  handle_destroy(info.hThread);
+
+  return error_unify_or_else(r, 1);
+}
+
+int process_wait(HANDLE process)
+{
+  assert(process);
+
+  int r = 0;
+
+  r = (int) WaitForSingleObject(process, INFINITE);
+  if ((DWORD) r == WAIT_FAILED) {
+    return error_unify(0);
+  }
+
+  DWORD status = 0;
+  r = GetExitCodeProcess(process, &status);
+  if (r == 0) {
+    return error_unify(r);
+  }
+
+  // `GenerateConsoleCtrlEvent` causes a process to exit with this exit code.
+  // Because `GenerateConsoleCtrlEvent` has roughly the same semantics as
+  // `SIGTERM`, we map its exit code to `SIGTERM`.
+  if (status == 3221225786) {
+    status = (DWORD) REPROC_SIGTERM;
+  }
+
+  assert(status <= INT_MAX);
+  return (int) status;
+}
+
+int process_terminate(HANDLE process)
+{
+  assert(process && process != PROCESS_INVALID);
+
+  // `GenerateConsoleCtrlEvent` can only be called on a process group. To call
+  // `GenerateConsoleCtrlEvent` on a single child process it has to be put in
+  // its own process group (which we did when starting the child process).
+  BOOL r = GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, GetProcessId(process));
+
+  return error_unify(r);
+}
+
+int process_kill(HANDLE process)
+{
+  assert(process && process != PROCESS_INVALID);
+
+  // We use 137 (`SIGKILL`) as the exit status because it is the same exit
+  // status as a process that is stopped with the `SIGKILL` signal on POSIX
+  // systems.
+  BOOL r = TerminateProcess(process, (DWORD) REPROC_SIGKILL);
+
+  return error_unify(r);
+}
+
+HANDLE process_destroy(HANDLE process)
+{
+  return handle_destroy(process);
+}

--- a/reproc/src/redirect.h
+++ b/reproc/src/redirect.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "handle.h"
+#include "pipe.h"
+
+// Keep in sync with `REPROC_STREAM`.
+typedef enum {
+  REDIRECT_STREAM_IN,
+  REDIRECT_STREAM_OUT,
+  REDIRECT_STREAM_ERR
+} REDIRECT_STREAM;
+
+int redirect_parent(handle_type *out, REDIRECT_STREAM stream);
+
+int redirect_discard(handle_type *out, REDIRECT_STREAM stream);

--- a/reproc/src/redirect.posix.c
+++ b/reproc/src/redirect.posix.c
@@ -1,0 +1,66 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "redirect.h"
+
+#include "error.h"
+#include "pipe.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+static FILE *stream_to_file(REDIRECT_STREAM stream)
+{
+  switch (stream) {
+    case REDIRECT_STREAM_IN:
+      return stdin;
+    case REDIRECT_STREAM_OUT:
+      return stdout;
+    case REDIRECT_STREAM_ERR:
+      return stderr;
+  }
+
+  return NULL;
+}
+
+int redirect_parent(int *out, REDIRECT_STREAM stream)
+{
+  assert(out);
+
+  int r = -EINVAL;
+
+  FILE *file = stream_to_file(stream);
+  if (file == NULL) {
+    return r;
+  }
+
+  r = fileno(file);
+  if (r < 0) {
+    if (errno == EBADF) {
+      r = -EPIPE;
+    }
+
+    return error_unify(r);
+  }
+
+  *out = r; // `r` contains the duplicated file descriptor.
+
+  return 0;
+}
+
+int redirect_discard(int *out, REDIRECT_STREAM stream)
+{
+  assert(out);
+
+  int mode = stream == REDIRECT_STREAM_IN ? O_RDONLY : O_WRONLY;
+
+  int r = open("/dev/null", mode | O_CLOEXEC);
+  if (r < 0) {
+    return error_unify(r);
+  }
+
+  *out = r;
+
+  return 0;
+}

--- a/reproc/src/redirect.win32.c
+++ b/reproc/src/redirect.win32.c
@@ -1,0 +1,73 @@
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+
+#include "redirect.h"
+
+#include "error.h"
+#include "pipe.h"
+
+#include <assert.h>
+#include <windows.h>
+
+static DWORD stream_to_id(REDIRECT_STREAM stream)
+{
+  switch (stream) {
+    case REDIRECT_STREAM_IN:
+      return STD_INPUT_HANDLE;
+    case REDIRECT_STREAM_OUT:
+      return STD_OUTPUT_HANDLE;
+    case REDIRECT_STREAM_ERR:
+      return STD_ERROR_HANDLE;
+  }
+
+  return 0;
+}
+
+int redirect_parent(HANDLE *out, REDIRECT_STREAM stream)
+{
+  assert(out);
+
+  int r = 0;
+
+  DWORD id = stream_to_id(stream);
+  if (id == 0) {
+    return -ERROR_INVALID_PARAMETER;
+  }
+
+  HANDLE *handle = GetStdHandle(id);
+  if (handle == INVALID_HANDLE_VALUE) {
+    return error_unify(r);
+  }
+
+  if (handle == NULL) {
+    return -ERROR_BROKEN_PIPE;
+  }
+
+  *out = handle;
+
+  return 0;
+}
+
+enum { FILE_NO_SHARE = 0, FILE_NO_TEMPLATE = 0 };
+
+static SECURITY_ATTRIBUTES INHERIT = { .nLength = sizeof(SECURITY_ATTRIBUTES),
+                                       .bInheritHandle = true,
+                                       .lpSecurityDescriptor = NULL };
+
+int redirect_discard(HANDLE *out, REDIRECT_STREAM stream)
+{
+  assert(out);
+
+  DWORD mode = stream == REDIRECT_STREAM_IN ? GENERIC_READ : GENERIC_WRITE;
+  int r = 0;
+
+  HANDLE handle = CreateFile("NUL", mode, FILE_NO_SHARE, &INHERIT,
+                             OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+                             (HANDLE) FILE_NO_TEMPLATE);
+  if (handle == INVALID_HANDLE_VALUE) {
+    return error_unify(r);
+  }
+
+  *out = handle;
+
+  return 0;
+}

--- a/reproc/src/reproc.c
+++ b/reproc/src/reproc.c
@@ -1,0 +1,727 @@
+#include <reproc/reproc.h>
+
+#include "clock.h"
+#include "error.h"
+#include "handle.h"
+#include "init.h"
+#include "macro.h"
+#include "pipe.h"
+#include "process.h"
+#include "redirect.h"
+
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+
+struct reproc_t {
+  process_type handle;
+  struct {
+    pipe_type in;
+    pipe_type out;
+    pipe_type err;
+    pipe_type exit;
+  } pipe;
+  int status;
+  reproc_stop_actions stop;
+  int timeout;
+  int64_t deadline;
+};
+
+enum { STATUS_NOT_STARTED = -1, STATUS_IN_PROGRESS = -2, STATUS_IN_CHILD = -3 };
+
+const int REPROC_SIGKILL = UINT8_MAX + 9;
+const int REPROC_SIGTERM = UINT8_MAX + 15;
+
+const int REPROC_INFINITE = -1;
+const int REPROC_DEADLINE = -2;
+
+static int
+parse_redirect(reproc_redirect *redirect, bool parent, bool discard, FILE *file)
+{
+  if (file) {
+    ASSERT_EINVAL(!redirect->type && !redirect->handle && !redirect->file);
+    redirect->type = REPROC_REDIRECT_FILE;
+    redirect->file = file;
+  }
+
+  if (redirect->type == REPROC_REDIRECT_HANDLE || redirect->handle) {
+    ASSERT_EINVAL(!redirect->type || redirect->type == REPROC_REDIRECT_HANDLE);
+    ASSERT_EINVAL(redirect->handle);
+    ASSERT_EINVAL(!redirect->file);
+    redirect->type = REPROC_REDIRECT_HANDLE;
+  }
+
+  if (redirect->type == REPROC_REDIRECT_FILE || redirect->file) {
+    ASSERT_EINVAL(!redirect->type || redirect->type == REPROC_REDIRECT_FILE);
+    ASSERT_EINVAL(redirect->file);
+    ASSERT_EINVAL(!redirect->handle);
+    redirect->type = REPROC_REDIRECT_FILE;
+  }
+
+  if (!redirect->type) {
+    if (parent) {
+      ASSERT_EINVAL(!discard);
+      redirect->type = REPROC_REDIRECT_PARENT;
+    } else if (discard) {
+      ASSERT_EINVAL(!parent);
+      redirect->type = REPROC_REDIRECT_DISCARD;
+    } else {
+      redirect->type = REPROC_REDIRECT_PIPE;
+    }
+  }
+
+  return 0;
+}
+
+static int parse_options(const char *const *argv, reproc_options *options)
+{
+  assert(options);
+
+  int r = -1;
+
+  r = parse_redirect(&options->redirect.in, options->redirect.parent,
+                     options->redirect.discard, NULL);
+  if (r < 0) {
+    return r;
+  }
+
+  r = parse_redirect(&options->redirect.out, options->redirect.parent,
+                     options->redirect.discard, options->redirect.file);
+  if (r < 0) {
+    return r;
+  }
+
+  r = parse_redirect(&options->redirect.err, options->redirect.parent,
+                     options->redirect.discard, options->redirect.file);
+  if (r < 0) {
+    return r;
+  }
+
+  if (options->input.data != NULL || options->input.size > 0) {
+    ASSERT_EINVAL(options->input.data != NULL);
+    ASSERT_EINVAL(options->input.size > 0);
+    ASSERT_EINVAL(options->redirect.in.type == REPROC_REDIRECT_PIPE);
+  }
+
+  if (options->fork) {
+    ASSERT_EINVAL(argv == NULL);
+  } else {
+    ASSERT_EINVAL(argv != NULL);
+    ASSERT_EINVAL(argv[0] != NULL);
+  }
+
+  // Default to waiting indefinitely but still allow setting a timeout of zero
+  // by setting `timeout` to `REPROC_NONBLOCKING`.
+  if (options->timeout == 0) {
+    options->timeout = REPROC_INFINITE;
+  }
+
+  if (options->deadline == 0) {
+    options->deadline = REPROC_INFINITE;
+  }
+
+  bool is_noop = options->stop.first.action == REPROC_STOP_NOOP &&
+                 options->stop.second.action == REPROC_STOP_NOOP &&
+                 options->stop.third.action == REPROC_STOP_NOOP;
+
+  if (is_noop) {
+    options->stop.first.action = REPROC_STOP_WAIT;
+    options->stop.first.timeout = REPROC_DEADLINE;
+    options->stop.second.action = REPROC_STOP_TERMINATE;
+    options->stop.second.timeout = REPROC_INFINITE;
+  }
+
+  return 0;
+}
+
+static int
+redirect_pipe(pipe_type *parent, handle_type *child, REPROC_STREAM stream)
+{
+  assert(parent);
+  assert(child);
+
+  pipe_type pipe[] = { PIPE_INVALID, PIPE_INVALID };
+
+  int r = pipe_init(&pipe[0], &pipe[1]);
+  if (r < 0) {
+    return r;
+  }
+
+  *parent = stream == REPROC_STREAM_IN ? pipe[1] : pipe[0];
+  *child = stream == REPROC_STREAM_IN ? (handle_type) pipe[0]
+                                      : (handle_type) pipe[1];
+
+  r = pipe_nonblocking(*parent, true);
+
+  return error_unify(r);
+}
+
+static int redirect(pipe_type *parent,
+                    handle_type *child,
+                    REPROC_STREAM stream,
+                    reproc_redirect redirect,
+                    handle_type out)
+{
+  assert(parent);
+  assert(child);
+
+  int r = -1;
+
+  switch (redirect.type) {
+
+    case REPROC_REDIRECT_PIPE:
+      r = redirect_pipe(parent, child, stream);
+      break;
+
+    case REPROC_REDIRECT_PARENT:
+      r = redirect_parent(child, (REDIRECT_STREAM) stream);
+      if (r == REPROC_EPIPE) {
+        // Discard if the corresponding parent stream is closed.
+        r = redirect_discard(child, (REDIRECT_STREAM) stream);
+      }
+
+      if (r < 0) {
+        break;
+      }
+
+      *parent = PIPE_INVALID;
+
+      break;
+
+    case REPROC_REDIRECT_DISCARD:
+      r = redirect_discard(child, (REDIRECT_STREAM) stream);
+      if (r < 0) {
+        break;
+      }
+
+      *parent = PIPE_INVALID;
+
+      break;
+
+    case REPROC_REDIRECT_HANDLE:
+      assert(redirect.handle);
+
+      r = 0;
+
+      *child = redirect.handle;
+      *parent = PIPE_INVALID;
+
+      break;
+
+    case REPROC_REDIRECT_FILE:
+      assert(redirect.file);
+
+      r = handle_from(redirect.file, child);
+      if (r < 0) {
+        break;
+      }
+
+      *parent = PIPE_INVALID;
+
+      break;
+
+    case REPROC_REDIRECT_STDOUT:
+      assert(stream == REPROC_STREAM_ERR);
+      assert(out != HANDLE_INVALID);
+
+      r = 0;
+
+      *child = out;
+      *parent = PIPE_INVALID;
+
+      break;
+
+    default:
+      r = REPROC_EINVAL;
+      break;
+  }
+
+  return r;
+}
+
+static handle_type redirect_destroy(handle_type handle, REPROC_REDIRECT type)
+{
+  switch (type) {
+    case REPROC_REDIRECT_PIPE:
+      // We know `handle` is a pipe if `REDIRECT_PIPE` is used so the cast is
+      // safe. This little hack prevents us from having to introduce a generic
+      // handle type.
+      pipe_destroy((pipe_type) handle);
+      break;
+    case REPROC_REDIRECT_DISCARD:
+      handle_destroy(handle);
+      break;
+    case REPROC_REDIRECT_PARENT:
+    case REPROC_REDIRECT_FILE:
+    case REPROC_REDIRECT_HANDLE:
+    case REPROC_REDIRECT_STDOUT:
+      break;
+  }
+
+  return HANDLE_INVALID;
+}
+
+static int expiry(int timeout, int64_t deadline)
+{
+  if (timeout == REPROC_INFINITE && deadline == REPROC_INFINITE) {
+    return REPROC_INFINITE;
+  }
+
+  if (deadline == REPROC_INFINITE) {
+    return timeout;
+  }
+
+  int64_t now = reproc_now();
+
+  if (now >= deadline) {
+    return 0;
+  }
+
+  // `deadline` exceeds `reproc_now` by at most a full `int` so the cast is
+  // safe.
+  int remaining = (int) (deadline - now);
+
+  if (timeout == REPROC_INFINITE) {
+    return remaining;
+  }
+
+  return MIN(timeout, remaining);
+}
+
+static int find_earliest_expiry(reproc_event_source *sources,
+                                size_t num_sources)
+{
+  assert(sources);
+  assert(num_sources > 0 && num_sources <= INT_MAX);
+
+  int earliest = 0;
+  int min = REPROC_INFINITE;
+
+  for (int i = 0; i < (int) num_sources; i++) {
+    reproc_t *process = sources[i].process;
+    int current = expiry(process->timeout, process->deadline);
+
+    if (min == REPROC_INFINITE || current < min) {
+      earliest = i;
+      min = current;
+    }
+  }
+
+  return earliest;
+}
+
+reproc_t *reproc_new(void)
+{
+  reproc_t *process = malloc(sizeof(reproc_t));
+  if (process == NULL) {
+    return NULL;
+  }
+
+  *process = (reproc_t){ .handle = PROCESS_INVALID,
+                         .pipe = { .in = PIPE_INVALID,
+                                   .out = PIPE_INVALID,
+                                   .err = PIPE_INVALID,
+                                   .exit = PIPE_INVALID },
+                         .status = STATUS_NOT_STARTED,
+                         .timeout = REPROC_INFINITE,
+                         .deadline = REPROC_INFINITE };
+
+  return process;
+}
+
+int reproc_start(reproc_t *process,
+                 const char *const *argv,
+                 reproc_options options)
+{
+  ASSERT_EINVAL(process);
+  ASSERT_EINVAL(process->status == STATUS_NOT_STARTED);
+
+  struct {
+    handle_type in;
+    handle_type out;
+    handle_type err;
+    pipe_type exit;
+  } child = { HANDLE_INVALID, HANDLE_INVALID, HANDLE_INVALID, PIPE_INVALID };
+  int r = -1;
+
+  r = init();
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = parse_options(argv, &options);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = redirect(&process->pipe.in, &child.in, REPROC_STREAM_IN,
+               options.redirect.in, HANDLE_INVALID);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = redirect(&process->pipe.out, &child.out, REPROC_STREAM_OUT,
+               options.redirect.out, HANDLE_INVALID);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = redirect(&process->pipe.err, &child.err, REPROC_STREAM_ERR,
+               options.redirect.err, child.out);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = pipe_init(&process->pipe.exit, &child.exit);
+  if (r < 0) {
+    goto finish;
+  }
+
+  if (options.input.data != NULL) {
+    // `reproc_write` only needs the child process stdin pipe to be initialized.
+    size_t written = 0;
+
+    while (written < options.input.size) {
+      r = reproc_write(process, options.input.data + written,
+                       options.input.size - written);
+      if (r < 0) {
+        goto finish;
+      }
+
+      assert(written + (size_t) r <= options.input.size);
+      written += (size_t) r;
+    }
+
+    r = reproc_close(process, REPROC_STREAM_IN);
+    if (r < 0) {
+      goto finish;
+    }
+  }
+
+  struct process_options process_options = {
+    .environment = options.environment,
+    .working_directory = options.working_directory,
+    .handle = { .in = child.in,
+                .out = child.out,
+                .err = child.err,
+                .exit = (handle_type) child.exit }
+  };
+
+  r = process_start(&process->handle, argv, process_options);
+  if (r < 0) {
+    goto finish;
+  }
+
+  if (r > 0) {
+    process->stop = options.stop;
+    process->timeout = options.timeout;
+
+    if (options.deadline != REPROC_INFINITE) {
+      process->deadline = reproc_now() + options.deadline;
+    }
+  }
+
+finish:
+  // Either an error has ocurred or the child pipe endpoints have been copied to
+  // the stdin/stdout/stderr streams of the child process. Either way, they can
+  // be safely closed.
+  redirect_destroy(child.in, options.redirect.in.type);
+  redirect_destroy(child.out, options.redirect.out.type);
+  redirect_destroy(child.err, options.redirect.err.type);
+  pipe_destroy(child.exit);
+
+  if (r < 0) {
+    process->handle = process_destroy(process->handle);
+    process->pipe.in = pipe_destroy(process->pipe.in);
+    process->pipe.out = pipe_destroy(process->pipe.out);
+    process->pipe.err = pipe_destroy(process->pipe.err);
+    process->pipe.exit = pipe_destroy(process->pipe.exit);
+    deinit();
+  } else if (r == 0) {
+    process->handle = PROCESS_INVALID;
+    // `process_start` has already taken care of closing the handles for us.
+    process->pipe.in = PIPE_INVALID;
+    process->pipe.out = PIPE_INVALID;
+    process->pipe.err = PIPE_INVALID;
+    process->pipe.exit = PIPE_INVALID;
+    process->status = STATUS_IN_CHILD;
+  } else {
+    process->status = STATUS_IN_PROGRESS;
+  }
+
+  return r;
+}
+
+static bool contains_valid_pipe(pipe_set *sets, size_t num_sets)
+{
+  for (size_t i = 0; i < num_sets; i++) {
+    if (sets[i].in != PIPE_INVALID || sets[i].out != PIPE_INVALID ||
+        sets[i].err != PIPE_INVALID) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+int reproc_poll(reproc_event_source *sources, size_t num_sources)
+{
+  ASSERT_EINVAL(sources);
+  ASSERT_EINVAL(num_sources > 0);
+  ASSERT_EINVAL(num_sources <= INT_MAX);
+
+  int earliest = find_earliest_expiry(sources, num_sources);
+  int timeout = expiry(sources[earliest].process->timeout,
+                       sources[earliest].process->deadline);
+  ASSERT_RETURN(timeout != 0, REPROC_ETIMEDOUT);
+
+  int r = REPROC_ENOMEM;
+
+  pipe_set *sets = calloc(sizeof(pipe_set), num_sources);
+  if (sets == NULL) {
+    return r;
+  }
+
+  for (size_t i = 0; i < num_sources; i++) {
+    pipe_set *set = sets + i;
+    reproc_t *process = sources[i].process;
+    int interests = sources[i].interests;
+
+    set->in = interests & REPROC_EVENT_IN ? process->pipe.in : PIPE_INVALID;
+    set->out = interests & REPROC_EVENT_OUT ? process->pipe.out : PIPE_INVALID;
+    set->err = interests & REPROC_EVENT_ERR ? process->pipe.err : PIPE_INVALID;
+    set->exit = interests & REPROC_EVENT_EXIT ? process->pipe.exit
+                                              : PIPE_INVALID;
+  }
+
+  if (!contains_valid_pipe(sets, num_sources)) {
+    r = REPROC_EPIPE;
+    goto finish;
+  }
+
+  r = pipe_wait(sets, num_sources, timeout);
+
+  if (r == REPROC_ETIMEDOUT) {
+    sources[earliest].events = REPROC_EVENT_TIMEOUT;
+    r = 0;
+    goto finish;
+  }
+
+  if (r < 0) {
+    goto finish;
+  }
+
+  for (size_t i = 0; i < num_sources; i++) {
+    sources[i].events = sets[i].events;
+  }
+
+finish:
+  free(sets);
+
+  return r;
+}
+
+int reproc_read(reproc_t *process,
+                REPROC_STREAM stream,
+                uint8_t *buffer,
+                size_t size)
+{
+  ASSERT_EINVAL(process);
+  ASSERT_EINVAL(process->status != STATUS_IN_CHILD);
+  ASSERT_EINVAL(stream == REPROC_STREAM_OUT || stream == REPROC_STREAM_ERR);
+  ASSERT_EINVAL(buffer);
+
+  pipe_type *pipe = stream == REPROC_STREAM_OUT ? &process->pipe.out
+                                                : &process->pipe.err;
+  if (*pipe == PIPE_INVALID) {
+    return REPROC_EPIPE;
+  }
+
+  int r = pipe_read(*pipe, buffer, size);
+
+  if (r == REPROC_EPIPE) {
+    *pipe = pipe_destroy(*pipe);
+  }
+
+  return r;
+}
+
+int reproc_write(reproc_t *process, const uint8_t *buffer, size_t size)
+{
+  ASSERT_EINVAL(process);
+  ASSERT_EINVAL(process->status != STATUS_IN_CHILD);
+
+  if (buffer == NULL) {
+    // Allow `NULL` buffers but only if `size == 0`.
+    ASSERT_EINVAL(size == 0);
+    return 0;
+  }
+
+  if (process->pipe.in == PIPE_INVALID) {
+    return REPROC_EPIPE;
+  }
+
+  int r = pipe_write(process->pipe.in, buffer, size);
+
+  if (r == REPROC_EPIPE) {
+    process->pipe.in = pipe_destroy(process->pipe.in);
+  }
+
+  return r;
+}
+
+int reproc_close(reproc_t *process, REPROC_STREAM stream)
+{
+  ASSERT_EINVAL(process);
+  ASSERT_EINVAL(process->status != STATUS_IN_CHILD);
+
+  switch (stream) {
+    case REPROC_STREAM_IN:
+      process->pipe.in = pipe_destroy(process->pipe.in);
+      break;
+    case REPROC_STREAM_OUT:
+      process->pipe.out = pipe_destroy(process->pipe.out);
+      break;
+    case REPROC_STREAM_ERR:
+      process->pipe.err = pipe_destroy(process->pipe.err);
+      break;
+    default:
+      return REPROC_EINVAL;
+  }
+
+  return 0;
+}
+
+int reproc_wait(reproc_t *process, int timeout)
+{
+  ASSERT_EINVAL(process);
+  ASSERT_EINVAL(process->status != STATUS_IN_CHILD);
+  ASSERT_EINVAL(process->status != STATUS_NOT_STARTED);
+
+  int r = -1;
+
+  if (process->status >= 0) {
+    return process->status;
+  }
+
+  if (timeout == REPROC_DEADLINE) {
+    // If the deadline has expired, `expiry` returns 0 which means we'll only
+    // check if the process is still running.
+    timeout = expiry(REPROC_INFINITE, process->deadline);
+  }
+
+  pipe_set set = { .in = PIPE_INVALID,
+                   .out = PIPE_INVALID,
+                   .err = PIPE_INVALID,
+                   .exit = process->pipe.exit };
+
+  r = pipe_wait(&set, 1, timeout);
+  if (r < 0) {
+    return r;
+  }
+
+  assert(set.events & PIPE_EVENT_EXIT);
+
+  r = process_wait(process->handle);
+  if (r < 0) {
+    return r;
+  }
+
+  process->pipe.exit = pipe_destroy(process->pipe.exit);
+
+  return process->status = r;
+}
+
+int reproc_terminate(reproc_t *process)
+{
+  ASSERT_EINVAL(process);
+  ASSERT_EINVAL(process->status != STATUS_IN_CHILD);
+  ASSERT_EINVAL(process->status != STATUS_NOT_STARTED);
+
+  if (process->status >= 0) {
+    return 0;
+  }
+
+  return process_terminate(process->handle);
+}
+
+int reproc_kill(reproc_t *process)
+{
+  ASSERT_EINVAL(process);
+  ASSERT_EINVAL(process->status != STATUS_IN_CHILD);
+  ASSERT_EINVAL(process->status != STATUS_NOT_STARTED);
+
+  if (process->status >= 0) {
+    return 0;
+  }
+
+  return process_kill(process->handle);
+}
+
+int reproc_stop(reproc_t *process, reproc_stop_actions stop)
+{
+  ASSERT_EINVAL(process);
+  ASSERT_EINVAL(process->status != STATUS_IN_CHILD);
+  ASSERT_EINVAL(process->status != STATUS_NOT_STARTED);
+
+  reproc_stop_action actions[] = { stop.first, stop.second, stop.third };
+  int r = -1;
+
+  for (size_t i = 0; i < ARRAY_SIZE(actions); i++) {
+    switch (actions[i].action) {
+      case REPROC_STOP_NOOP:
+        continue;
+      case REPROC_STOP_WAIT:
+        r = 0;
+        break;
+      case REPROC_STOP_TERMINATE:
+        r = reproc_terminate(process);
+        break;
+      case REPROC_STOP_KILL:
+        r = reproc_kill(process);
+        break;
+      default:
+        return REPROC_EINVAL;
+    }
+
+    // Stop if `reproc_terminate` or `reproc_kill` fail.
+    if (r < 0) {
+      break;
+    }
+
+    r = reproc_wait(process, actions[i].timeout);
+    if (r != REPROC_ETIMEDOUT) {
+      break;
+    }
+  }
+
+  return r;
+}
+
+reproc_t *reproc_destroy(reproc_t *process)
+{
+  ASSERT_RETURN(process, NULL);
+
+  if (process->status == STATUS_IN_PROGRESS) {
+    reproc_stop(process, process->stop);
+  }
+
+  process->handle = process_destroy(process->handle);
+  process->pipe.in = pipe_destroy(process->pipe.in);
+  process->pipe.out = pipe_destroy(process->pipe.out);
+  process->pipe.err = pipe_destroy(process->pipe.err);
+  process->pipe.exit = pipe_destroy(process->pipe.exit);
+
+  if (process->status != STATUS_NOT_STARTED) {
+    deinit();
+  }
+
+  free(process);
+
+  return NULL;
+}
+
+const char *reproc_strerror(int error)
+{
+  return error_string(error);
+}

--- a/reproc/src/run.c
+++ b/reproc/src/run.c
@@ -1,0 +1,46 @@
+#include <reproc/run.h>
+
+#include <reproc/sink.h>
+
+int reproc_run(const char *const *argv, reproc_options options)
+{
+  if (!options.redirect.discard) {
+    options.redirect.parent = true;
+  }
+
+  return reproc_run_ex(argv, options, REPROC_SINK_NULL, REPROC_SINK_NULL);
+}
+
+int reproc_run_ex(const char *const *argv,
+                  reproc_options options,
+                  reproc_sink out,
+                  reproc_sink err)
+{
+  reproc_t *process = NULL;
+  int r = REPROC_ENOMEM;
+
+  process = reproc_new();
+  if (process == NULL) {
+    goto finish;
+  }
+
+  r = reproc_start(process, argv, options);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = reproc_drain(process, out, err);
+  if (r < 0) {
+    goto finish;
+  }
+
+  r = reproc_wait(process, REPROC_DEADLINE);
+  if (r < 0) {
+    goto finish;
+  }
+
+finish:
+  reproc_destroy(process);
+
+  return r;
+}

--- a/reproc/src/sink.c
+++ b/reproc/src/sink.c
@@ -1,0 +1,124 @@
+#include <reproc/sink.h>
+
+#include "error.h"
+#include "macro.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+int reproc_drain(reproc_t *process, reproc_sink out, reproc_sink err)
+{
+  ASSERT_EINVAL(process);
+  ASSERT_EINVAL(out.function);
+  ASSERT_EINVAL(err.function);
+
+  const uint8_t initial = 0;
+
+  // A single call to `read` might contain multiple messages. By always calling
+  // both sinks once with no data before reading, we give them the chance to
+  // process all previous output one by one before reading from the child
+  // process again.
+  if (!out.function(REPROC_STREAM_IN, &initial, 0, out.context) ||
+      !err.function(REPROC_STREAM_IN, &initial, 0, err.context)) {
+    return 0;
+  }
+
+  uint8_t buffer[4096];
+  int r = -1;
+
+  while (true) {
+    reproc_event_source source = { process, REPROC_EVENT_OUT | REPROC_EVENT_ERR,
+                                   0 };
+
+    r = reproc_poll(&source, 1);
+    if (r < 0) {
+      break;
+    }
+
+    if (source.events & REPROC_EVENT_TIMEOUT) {
+      r = REPROC_ETIMEDOUT;
+      break;
+    }
+
+    REPROC_STREAM stream = source.events & REPROC_EVENT_OUT ? REPROC_STREAM_OUT
+                                                            : REPROC_STREAM_ERR;
+
+    r = reproc_read(process, stream, buffer, ARRAY_SIZE(buffer));
+    if (r == REPROC_EPIPE) {
+      continue;
+    }
+
+    if (r < 0) {
+      break;
+    }
+
+    size_t bytes_read = (size_t) r;
+
+    reproc_sink sink = stream == REPROC_STREAM_OUT ? out : err;
+
+    // `sink` returns false to tell us to stop reading.
+    if (!sink.function(stream, buffer, bytes_read, sink.context)) {
+      break;
+    }
+  }
+
+  return r == REPROC_EPIPE ? 0 : r;
+}
+
+static bool sink_string(REPROC_STREAM stream,
+                        const uint8_t *buffer,
+                        size_t size,
+                        void *context)
+{
+  (void) stream;
+
+  char **string = (char **) context;
+  size_t string_size = *string == NULL ? 0 : strlen(*string);
+
+  char *realloc_result = (char *) realloc(*string, string_size + size + 1);
+  if (realloc_result == NULL) {
+    free(*string);
+    *string = NULL;
+    return false;
+  } else {
+    *string = realloc_result;
+  }
+
+  memcpy(*string + string_size, buffer, size);
+
+  (*string)[string_size + size] = '\0';
+
+  return true;
+}
+
+reproc_sink reproc_sink_string(char **output)
+{
+  return (reproc_sink){ sink_string, output };
+}
+
+static bool sink_discard(REPROC_STREAM stream,
+                         const uint8_t *buffer,
+                         size_t size,
+                         void *context)
+{
+  (void) stream;
+  (void) buffer;
+  (void) size;
+  (void) context;
+
+  return true;
+}
+
+reproc_sink reproc_sink_discard(void)
+{
+  return (reproc_sink){ sink_discard, NULL };
+}
+
+const reproc_sink REPROC_SINK_NULL = { sink_discard, NULL };
+
+void *reproc_free(void *ptr)
+{
+  ASSERT_RETURN(ptr, NULL);
+  free(ptr);
+  return NULL;
+}


### PR DESCRIPTION
I think I've gotten [reproc](https://github.com/DaanDeMeyer/reproc) to the point where it can be used to handle the cross-platform job control of samurai.

I've written a small proof of concept with the minimum amount of changes necessary to replace the current usage of `posix_spawn` with reproc instead. As a test, I'm currently busy compiling LLVM with this PR.

To test these changes:

```
git checkout https://github.com/DaanDeMeyer/samurai.git --branch reproc
meson build
ninja -C build
sudo ln -sf <path-to-samu-in-build-dir> /usr/bin/ninja 
```

As to why I've made this pull request, I'm interested in adding Windows support for Samurai. I'm making this draft pull request mainly to ask if you would be interested in adding reproc as a dependency in order to get Windows support working.