### PR TITLE
Add .clang-format file and reformat.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: LLVM
+AlignEscapedNewlines: DontAlign
+AlwaysBreakAfterDefinitionReturnType: All
+BreakBeforeBraces: Linux
+ColumnLimit: 0
+IndentWidth: 4
+SortIncludes: false
+TabWidth: 4
+UseTab: ForIndentation

--- a/arg.h
+++ b/arg.h
@@ -14,7 +14,7 @@ extern const char *argv0;
 			switch (*opt_)
 
 #define ARGEND \
-		} \
+	} \
 	}
 
 #define EARGF(x) \

--- a/build.c
+++ b/build.c
@@ -35,7 +35,8 @@ static bool consoleused;
 static struct timespec starttime;
 
 void
-buildreset(void) {
+buildreset(void)
+{
 	struct edge *e;
 	struct node *n;
 	size_t i;
@@ -590,5 +591,5 @@ build(void)
 		else
 			fatal("subcommand failed");
 	}
-	ntotal = 0;  /* reset in case we just rebuilt the manifest */
+	ntotal = 0; /* reset in case we just rebuilt the manifest */
 }

--- a/deps.c
+++ b/deps.c
@@ -40,7 +40,7 @@ specified previously in node records.
 */
 
 /* maximum record size (in bytes) */
-#define MAX_RECORD_SIZE (1<<19)
+#define MAX_RECORD_SIZE (1 << 19)
 
 struct nodearray {
 	struct node **node;
@@ -83,7 +83,7 @@ recordid(struct node *n)
 		fatal("ID record too large");
 	depswrite(&sz, 4, 1);
 	depswrite(n->path->s, 1, n->path->n);
-	depswrite((char [4]){0}, 1, sz - n->path->n - 4);
+	depswrite((char[4]){0}, 1, sz - n->path->n - 4);
 	chk = ~n->id;
 	depswrite(&chk, 4, 1);
 
@@ -403,7 +403,7 @@ depsparse(const char *name)
 					goto err;
 				}
 			} else if (!isblank(c)) {
-			    break;
+				break;
 			}
 			c = getc(f);
 		}

--- a/graph.h
+++ b/graph.h
@@ -54,14 +54,18 @@ struct edge {
 	/* how many inputs need to be pruned before all outputs can be pruned */
 	size_t nprune;
 
+	// clang-format off
+
 	enum {
-		FLAG_WORK      = 1<<0, /* scheduled for build */
-		FLAG_HASH      = 1<<1, /* calculated the command hash */
-		FLAG_DIRTY_IN  = 1<<3, /* dirty input */
-		FLAG_DIRTY_OUT = 1<<4, /* missing or outdated output */
+		FLAG_WORK      = 1 << 0, /* scheduled for build */
+		FLAG_HASH      = 1 << 1, /* calculated the command hash */
+		FLAG_DIRTY_IN  = 1 << 3, /* dirty input */
+		FLAG_DIRTY_OUT = 1 << 4, /* missing or outdated output */
 		FLAG_DIRTY     = FLAG_DIRTY_IN | FLAG_DIRTY_OUT,
-		FLAG_CYCLE     = 1<<5, /* used for cycle detection */
+		FLAG_CYCLE     = 1 << 5, /* used for cycle detection */
 	} flags;
+
+	// clang-format on
 
 	/* used to coordinate ready work in build() */
 	struct edge *worknext;

--- a/htab.c
+++ b/htab.c
@@ -142,6 +142,8 @@ murmurhash64a(const void *ptr, size_t len)
 		h *= m;
 	}
 
+	// clang-format off
+
 	switch (len & 0x7) {
 	case 7: h ^= (uint64_t)p[6] << 48;  /* fallthrough */
 	case 6: h ^= (uint64_t)p[5] << 40;  /* fallthrough */
@@ -152,6 +154,8 @@ murmurhash64a(const void *ptr, size_t len)
 	case 1: h ^= (uint64_t)p[0];
 		h *= m;
 	}
+
+	// clang-format on
 
 	h ^= h >> r;
 	h *= m;

--- a/htab.h
+++ b/htab.h
@@ -1,4 +1,4 @@
-#include <stdint.h>  /* for uint64_t */
+#include <stdint.h> /* for uint64_t */
 
 struct hashtablekey {
 	uint64_t hash;

--- a/log.c
+++ b/log.c
@@ -64,11 +64,11 @@ loginit(const char *builddir)
 	while (getline(&line, &sz, logfile) >= 0) {
 		++nline;
 		p = line;
-		if (!nextfield(&p))  /* start time */
+		if (!nextfield(&p)) /* start time */
 			continue;
-		if (!nextfield(&p))  /* end time */
+		if (!nextfield(&p)) /* end time */
 			continue;
-		s = nextfield(&p);  /* mtime (used for restat) */
+		s = nextfield(&p); /* mtime (used for restat) */
 		if (!s)
 			continue;
 		mtime = strtoll(s, &s, 10);
@@ -76,7 +76,7 @@ loginit(const char *builddir)
 			warn("corrupt build log: invalid mtime");
 			continue;
 		}
-		s = nextfield(&p);  /* output path */
+		s = nextfield(&p); /* output path */
 		if (!s)
 			continue;
 		n = nodeget(s, 0);
@@ -85,7 +85,7 @@ loginit(const char *builddir)
 		if (n->logmtime == MTIME_MISSING)
 			++nentry;
 		n->logmtime = mtime;
-		s = nextfield(&p);  /* command hash */
+		s = nextfield(&p); /* command hash */
 		if (!s)
 			continue;
 		n->hash = strtoull(s, &s, 16);

--- a/parse.c
+++ b/parse.c
@@ -96,7 +96,7 @@ parseedge(struct scanner *s, struct environment *env)
 	for (in = NULL, end = &in; (str = scanstring(s, true)); ++e->nin)
 		pushstr(&end, str);
 	e->inimpidx = e->nin;
-	p = scanpipe(s, 1|2);
+	p = scanpipe(s, 1 | 2);
 	if (p == 1) {
 		for (; (str = scanstring(s, true)); ++e->nin)
 			pushstr(&end, str);

--- a/samu.c
+++ b/samu.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>  /* for chdir */
+#include <unistd.h> /* for chdir */
 #include "arg.h"
 #include "build.h"
 #include "deps.h"
@@ -199,7 +199,9 @@ argdone:
 #ifdef _SC_NPROCESSORS_ONLN
 		int n = sysconf(_SC_NPROCESSORS_ONLN);
 		switch (n) {
-		case -1: case 0: case 1:
+		case -1:
+		case 0:
+		case 1:
 			buildopts.maxjobs = 2;
 			break;
 		case 2:

--- a/scan.c
+++ b/scan.c
@@ -79,7 +79,8 @@ crlf(struct scanner *s)
 }
 
 static bool
-singlespace(struct scanner *s) {
+singlespace(struct scanner *s)
+{
 	int c;
 
 	switch (s->chr) {
@@ -146,12 +147,12 @@ scankeyword(struct scanner *s, char **var)
 		const char *name;
 		int value;
 	} keywords[] = {
-		{"build",    BUILD},
-		{"default",  DEFAULT},
-		{"include",  INCLUDE},
-		{"pool",     POOL},
-		{"rule",     RULE},
-		{"subninja", SUBNINJA},
+	    {"build", BUILD},
+	    {"default", DEFAULT},
+	    {"include", INCLUDE},
+	    {"pool", POOL},
+	    {"rule", RULE},
+	    {"subninja", SUBNINJA},
 	};
 	int low = 0, high = LEN(keywords) - 1, mid, cmp;
 

--- a/tool.c
+++ b/tool.c
@@ -222,8 +222,8 @@ compdb(int argc, char *argv[])
 }
 
 static const struct tool tools[] = {
-	{"clean", clean},
-	{"compdb", compdb},
+    {"clean", clean},
+    {"compdb", compdb},
 };
 
 const struct tool *

--- a/tree.c
+++ b/tree.c
@@ -5,7 +5,7 @@
 #include "tree.h"
 #include "util.h"
 
-#define MAXH (sizeof(void*) * 8 * 3 / 2)
+#define MAXH (sizeof(void *) * 8 * 3 / 2)
 
 struct treenode {
 	char *key;
@@ -20,7 +20,8 @@ height(struct treenode *n)
 	return n ? n->height : 0;
 }
 
-static int rot(struct treenode **p, struct treenode *x, int dir /* deeper side */)
+static int
+rot(struct treenode **p, struct treenode *x, int dir /* deeper side */)
 {
 	struct treenode *y = x->child[dir];
 	struct treenode *z = y->child[!dir];

--- a/util.c
+++ b/util.c
@@ -115,7 +115,7 @@ void
 bufadd(struct buffer *buf, char c)
 {
 	if (buf->len >= buf->cap) {
-		buf->cap = buf->cap ? buf->cap * 2 : 1<<8;
+		buf->cap = buf->cap ? buf->cap * 2 : 1 << 8;
 		buf->data = realloc(buf->data, buf->cap);
 		if (!buf->data)
 			fatal("realloc:");
@@ -170,12 +170,13 @@ canonpath(struct string *path)
 	}
 	while (s < end) {
 		switch (s[0]) {
-		case  '/':
+		case '/':
 			++s;
 			continue;
 		case '.':
 			switch (s[1]) {
-			case '\0': case '/':
+			case '\0':
+			case '/':
 				s += 2;
 				continue;
 			case '.':


### PR DESCRIPTION
I did my absolute best to match the current style as much as possible. The only changes are stuff I couldn't configure in clang-format and inconsistencies that clang-format fixed. I also moved the extra set of braces into `ARGBEGIN` and `ARGEND` so that clang-format formats them better.

Open questions:

- I set the column limit to 100 to avoid too many lines being wrapped but it could just as well be set to 80. Depends on which one you prefer.
- Currently, trailing comments are indented by two spaces which is reduced by clang-format to one space. clang-format supports specifying the amount of spaces to use for trailing comments but only for `//` style comments. If preferred, I can update trailing comments to `//` style comments so we can keep the two space indentation.
- It's up to you whether you want to enforce this formatting in some way. I think it's easier to just add the occasional reformat commit once in a while when necessary.