### PR TITLE
Free old root environment, delete pools, change delevalstr argument type.

### DIFF
--- a/env.c
+++ b/env.c
@@ -18,12 +18,22 @@ struct pool consolepool = {.name = "console", .maxjobs = 1};
 static struct treenode *pools;
 
 static void addpool(struct pool *);
+static void delpool(void *);
+static void delrule(void *);
 
 void
 envinit(void)
 {
-	/* TODO: delete old root environment and pools (in case we rebuilt
-	 * build.ninja). for now, we leak memory. */
+	/* free old rootenv and pools in case we rebuilt the manifest
+	 * TODO: some memory is still leaked if subninja is used.
+	 * fixing this would probably require keeping a list of used
+	 * environments and traversing them here. */
+	if (rootenv) {
+		deltree(rootenv->bindings, free);
+		deltree(rootenv->rules, delrule);
+		deltree(pools, delpool);
+		free(rootenv);
+	}
 	rootenv = mkenv(NULL);
 	envaddrule(rootenv, &phonyrule);
 	pools = NULL;
@@ -178,6 +188,16 @@ mkrule(char *name)
 	return r;
 }
 
+static void
+delrule(void *ptr)
+{
+	struct rule *r = ptr;
+	if (r == &phonyrule)
+		return;
+	deltree(r->bindings, delevalstr);
+	free(r);
+}
+
 void
 ruleaddvar(struct rule *r, char *var, struct evalstring *val)
 {
@@ -223,6 +243,15 @@ addpool(struct pool *p)
 {
 	if (treeinsert(&pools, p->name, p))
 		fatal("pool '%s' redefined", p->name);
+}
+
+static void
+delpool(void *ptr)
+{	
+	struct pool *p = ptr;
+	if(p == &consolepool)
+		return;
+	free(p);
 }
 
 struct pool *

--- a/env.c
+++ b/env.c
@@ -29,9 +29,9 @@ envinit(void)
 	 * fixing this would probably require keeping a list of used
 	 * environments and traversing them here. */
 	if (rootenv) {
-		deltree(rootenv->bindings, free);
-		deltree(rootenv->rules, delrule);
-		deltree(pools, delpool);
+		deltree(rootenv->bindings, free, free);
+		deltree(rootenv->rules, NULL, delrule);
+		deltree(pools, NULL, delpool);
 		free(rootenv);
 	}
 	rootenv = mkenv(NULL);
@@ -194,7 +194,8 @@ delrule(void *ptr)
 	struct rule *r = ptr;
 	if (r == &phonyrule)
 		return;
-	deltree(r->bindings, delevalstr);
+	free(r->name);
+	deltree(r->bindings, free, delevalstr);
 	free(r);
 }
 
@@ -251,6 +252,7 @@ delpool(void *ptr)
 	struct pool *p = ptr;
 	if(p == &consolepool)
 		return;
+	free(p->name);
 	free(p);
 }
 

--- a/env.h
+++ b/env.h
@@ -16,14 +16,22 @@ struct pool {
 
 void envinit(void);
 
+/* create a new environment, with an optional parent */
 struct environment *mkenv(struct environment *);
+/* search environment and its parents for a variable, return the value or NULL if not found */
 struct string *envvar(struct environment *, char *);
+/* add to environment a variable and its value, replacing the old value if there is one */
 void envaddvar(struct environment *, char *, struct string *);
+/* using an environment and its parents variables, evaluate an unevaluated string, returning the result */
 struct string *enveval(struct environment *, struct evalstring *);
+/* search an environment and its parents for a rule, return the rule or NULL if not found */
 struct rule *envrule(struct environment *, char *);
+/* add a rule to an environment, fails if the rule already exists */
 void envaddrule(struct environment *, struct rule *);
 
+/* create rule with given name, bindings not allocated */
 struct rule *mkrule(char *);
+/* add to rule a variable and its value */
 void ruleaddvar(struct rule *, char *, struct evalstring *);
 
 /* create a new pool with the given name */
@@ -31,6 +39,7 @@ struct pool *mkpool(char *);
 /* lookup a pool by name. fails if it does not exist */
 struct pool *poolget(char *);
 
+/* return an edge's variable evaluated, optionally shell-escaped */
 struct string *edgevar(struct edge *, char *, _Bool);
 
 extern struct environment *rootenv;

--- a/graph.h
+++ b/graph.h
@@ -32,6 +32,7 @@ struct node {
 	_Bool dirty;
 };
 
+/* build rule, i.e., edge between inputs and outputs */
 struct edge {
 	struct rule *rule;
 	struct pool *pool;

--- a/graph.h
+++ b/graph.h
@@ -85,7 +85,7 @@ void nodeuse(struct node *, struct edge *);
 
 /* create a new edge with the given parent environment */
 struct edge *mkedge(struct environment *parent);
-/* compute the murmurhash64a of an edge comand and store it in the hash field */
+/* compute the murmurhash64a of an edge command and store it in the hash field */
 void edgehash(struct edge *);
 /* add dependencies from $depfile or .ninja_deps as implicit inputs */
 void edgeadddeps(struct edge *e, struct node **deps, size_t ndeps);

--- a/tree.c
+++ b/tree.c
@@ -14,6 +14,19 @@ struct treenode {
 	int height;
 };
 
+void
+deltree(struct treenode *n, void del(void *))
+{
+	if (!n)
+		return;
+	free(n->key);
+	if (del)
+		del(n->value);
+	deltree(n->child[0], del);
+	deltree(n->child[1], del);
+	free(n);
+}
+
 static inline int
 height(struct treenode *n)
 {

--- a/tree.c
+++ b/tree.c
@@ -15,15 +15,16 @@ struct treenode {
 };
 
 void
-deltree(struct treenode *n, void del(void *))
+deltree(struct treenode *n, void delkey(void *), void delval(void *))
 {
 	if (!n)
 		return;
-	free(n->key);
-	if (del)
-		del(n->value);
-	deltree(n->child[0], del);
-	deltree(n->child[1], del);
+	if (delkey)
+		delkey(n->key);
+	if (delval)
+		delval(n->value);
+	deltree(n->child[0], delkey, delval);
+	deltree(n->child[1], delkey, delval);
 	free(n);
 }
 

--- a/tree.h
+++ b/tree.h
@@ -1,6 +1,10 @@
+/* binary tree node, such that keys are sorted lexicographically for fast lookup */
 struct treenode;
 
+/* free a tree and its' children recursively, free values with a function */
 void deltree(struct treenode *, void(void *));
 
+/* search a binary tree for a key, return the key's value or NULL*/
 void *treefind(struct treenode *, const char *);
+/* insert into a binary tree a key and a value, return and replace the old treenode if the key already exists */
 void *treeinsert(struct treenode **, char *, void *);

--- a/tree.h
+++ b/tree.h
@@ -1,8 +1,8 @@
 /* binary tree node, such that keys are sorted lexicographically for fast lookup */
 struct treenode;
 
-/* free a tree and its' children recursively, free values with a function */
-void deltree(struct treenode *, void(void *));
+/* free a tree and its children recursively, free keys and values with a function */
+void deltree(struct treenode *, void(void *), void(void *));
 
 /* search a binary tree for a key, return the key's value or NULL*/
 void *treefind(struct treenode *, const char *);

--- a/tree.h
+++ b/tree.h
@@ -1,4 +1,6 @@
 struct treenode;
 
+void deltree(struct treenode *, void(void *));
+
 void *treefind(struct treenode *, const char *);
 void *treeinsert(struct treenode **, char *, void *);

--- a/util.c
+++ b/util.c
@@ -135,8 +135,9 @@ mkstr(size_t n)
 }
 
 void
-delevalstr(struct evalstring *str)
+delevalstr(void *ptr)
 {
+	struct evalstring *str = ptr;
 	struct evalstringpart *p, *next;
 
 	if (!str)

--- a/util.h
+++ b/util.h
@@ -42,7 +42,7 @@ void bufadd(struct buffer *buf, char c);
 struct string *mkstr(size_t n);
 
 /* delete an unevaluated string */
-void delevalstr(struct evalstring *);
+void delevalstr(void *);
 
 /* canonicalizes the given path by removing duplicate slashes, and
  * folding '/.' and 'foo/..' */


### PR DESCRIPTION
The new `deltree` function header, requires `del` function to have a generic argument type. So I had to change the delevalstr argument type to a `void *`