### PR TITLE
dyndep support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ ALL_CFLAGS=$(CFLAGS) -std=c99 -Wall -Wextra -Wpedantic
 OBJ=\
 	build.o\
 	deps.o\
+	dyndep.o\
 	env.o\
 	graph.o\
 	htab.o\

--- a/build.c
+++ b/build.c
@@ -106,6 +106,10 @@ queue(struct edge *e)
 {
 	struct edge **front = &work;
 
+	if (e->flags & FLAG_QUEUED)
+		return;
+	e->flags |= FLAG_QUEUED;
+
 	if (e->pool && e->rule != &phonyrule) {
 		if (e->pool->numjobs == e->pool->maxjobs)
 			front = &e->pool->work;

--- a/build.c
+++ b/build.c
@@ -443,6 +443,8 @@ edgedone(struct edge *e)
 	bool restat, prune, pruned;
 	int64_t old;
 
+	/* mark edge clean for dyndepload */
+	e->flags &= ~FLAG_DIRTY;
 
 	newest = NULL;
 	prune = pruned = false;

--- a/build.c
+++ b/build.c
@@ -360,6 +360,9 @@ nodedone(struct node *n, bool prune)
 	struct edge *e;
 	size_t i, j;
 
+	/* mark node clean for computedirty of edges with dyndeps */
+	n->dirty = false;
+
 	for (i = 0; i < n->nuse; ++i) {
 		e = n->use[i];
 		/* skip edges not used in this build */

--- a/build.c
+++ b/build.c
@@ -156,12 +156,15 @@ buildupdate(struct node *n)
 {
 	struct edge *e;
 	struct node *newest;
+	bool planned;
 	size_t i;
 
 	e = n->gen;
 	if (e->flags & FLAG_CYCLE)
 		fatal("dependency cycle involving '%s'", n->path->s);
 	e->flags |= FLAG_CYCLE | FLAG_WORK;
+	/* if the edge is already marked dirty ntotal was already updated */
+	planned = e->flags & FLAG_DIRTY;
 	for (i = e->outdynidx; i < e->nout; ++i) {
 		n = e->out[i];
 		if (n->mtime == MTIME_UNKNOWN) {
@@ -188,6 +191,8 @@ buildupdate(struct node *n)
 	if (e->flags & FLAG_DIRTY) {
 		if (e->nblock == 0)
 			queue(e);
+		if (!planned && e->rule != &phonyrule)
+			++ntotal;
 	}
 	e->flags &= ~FLAG_CYCLE;
 }

--- a/build.h
+++ b/build.h
@@ -12,5 +12,7 @@ extern struct buildoptions buildopts;
 void buildreset(void);
 /* schedule a particular target to be built */
 void buildadd(struct node *);
+/* reschedule a particular target to be built */
+void buildupdate(struct node *);
 /* execute rules to build the scheduled targets */
 void build(void);

--- a/build.ninja
+++ b/build.ninja
@@ -10,6 +10,7 @@ rule link
 
 build build.o: cc build.c
 build deps.o: cc deps.c
+build dyndep.o: cc dyndep.c
 build env.o: cc env.c
 build graph.o: cc graph.c
 build htab.o: cc htab.c
@@ -20,6 +21,6 @@ build scan.o: cc scan.c
 build tool.o: cc tool.c
 build tree.o: cc tree.c
 build util.o: cc util.c
-build samu: link build.o deps.o env.o graph.o htab.o log.o parse.o samu.o scan.o tool.o tree.o util.o
+build samu: link build.o deps.o dyndep.o env.o graph.o htab.o log.o parse.o samu.o scan.o tool.o tree.o util.o
 
 default samu

--- a/dyndep.c
+++ b/dyndep.c
@@ -89,7 +89,8 @@ parselet(struct scanner *s, struct evalstring **val)
 static void
 checkversion(const char *ver)
 {
-	if (strcmp(ver, dyndepversion) > 0)
+	int nmajor, nminor = 0;
+	if ((sscanf(ver, "%d.%d", &nmajor, &nminor) < 1) || (nmajor > 1))
 		fatal("ninja_dyndep_version %s is newer than %s", ver, dyndepversion);
 }
 

--- a/dyndep.c
+++ b/dyndep.c
@@ -263,8 +263,6 @@ dyndepload(struct dyndep *d, bool prune)
 		/* only update the node if it was previously added to the build */
 		if (n->gen->flags & FLAG_WORK)
 			buildupdate(n);
-		else
-			buildadd(n);
 		n->gen->flags &= ~FLAG_DYNDEP;
 	}
 

--- a/dyndep.c
+++ b/dyndep.c
@@ -1,0 +1,272 @@
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include "build.h"
+#include "dyndep.h"
+#include "env.h"
+#include "graph.h"
+#include "htab.h"
+#include "scan.h"
+#include "util.h"
+
+struct nodearray {
+	struct node **node;
+	size_t len;
+};
+
+const char *dyndepversion = "1.0";
+
+static struct dyndep *alldyndeps;
+
+void
+dyndepinit(void)
+{
+	struct dyndep *d;
+
+	/* delete old dyndeps in case we rebuilt the manifest */
+	while (alldyndeps) {
+		d = alldyndeps;
+		alldyndeps = d->allnext;
+		free(d->use);
+		free(d);
+	}
+}
+
+struct dyndep *
+mkdyndep(struct node *n)
+{
+	struct dyndep *d;
+
+	if (n->dyndep)
+		return n->dyndep;
+
+	d = xmalloc(sizeof(*d));
+	d->node = n;
+	d->use = NULL;
+	d->nuse = 0;
+	d->update = NULL;
+	d->nupdate = 0;
+	d->done = false;
+	d->allnext = alldyndeps;
+	alldyndeps = d;
+	n->dyndep = d;
+
+	return d;
+}
+
+void
+dyndepuse(struct dyndep *d, struct edge *e)
+{
+	e->dyndep = d;
+
+	/* allocate in powers of two */
+	if (!(d->nuse & (d->nuse - 1)))
+		d->use = xreallocarray(d->use, d->nuse ? d->nuse * 2 : 1, sizeof(e));
+	d->use[d->nuse++] = e;
+}
+
+static void
+dyndepupdate(struct dyndep *d, struct node *n)
+{
+	/* allocate in powers of two */
+	if (!(d->nupdate & (d->nupdate - 1)))
+		d->update = xreallocarray(d->update, d->nupdate ? d->nupdate * 2 : 1, sizeof(n));
+	d->update[d->nupdate++] = n;
+}
+
+static void
+parselet(struct scanner *s, struct evalstring **val)
+{
+	scanchar(s, '=');
+	*val = scanstring(s, false);
+	scannewline(s);
+}
+
+static void
+checkversion(const char *ver)
+{
+	if (strcmp(ver, dyndepversion) > 0)
+		fatal("ninja_dyndep_version %s is newer than %s", ver, dyndepversion);
+}
+
+static void
+dyndepparseedge(struct scanner *s, struct environment *env)
+{
+	struct dyndep *d;
+	struct edge *e;
+	struct node *n;
+	static struct nodearray nodes;
+	static size_t nodescap;
+	struct evalstring *str;
+	char *name;
+	struct string *val;
+
+	str = scanstring(s, true);
+	if (!str)
+		scanerror(s, "expected explicit output");
+
+	val = enveval(env, str);
+	n = nodeget(val->s, val->n);
+	if (!n)
+		fatal("unknown target '%s'", val->s);
+	e = n->gen;
+	if (!e)
+		fatal("no action to generate '%s' in dyndep", val->s);
+	free(val);
+	d = e->dyndep;
+	if (!d)
+		fatal("target '%s' does not mention this dyndep", n->path->s);
+
+	dyndepupdate(d, n);
+
+	nodes.len = 0;
+	if (scanpipe(s, 1)) {
+		for (; (str = scanstring(s, true)); ) {
+			val = enveval(e->env, str);
+			canonpath(val);
+			if (nodes.len == nodescap) {
+				nodescap = nodes.node ? nodescap * 2 : 32;
+				nodes.node = xreallocarray(nodes.node, nodescap, sizeof(nodes.node[0]));
+			}
+			nodes.node[nodes.len++] = mknode(val);
+		}
+	}
+	if (nodes.len)
+		edgeadddynouts(e, nodes.node, nodes.len);
+
+	scanchar(s, ':');
+	name = scanname(s);
+	if (strcmp(name, "dyndep") != 0)
+		fatal("unexpected rule '%s' in dyndep", name);
+	free(name);
+
+	nodes.len = 0;
+	if (scanpipe(s, 1)) {
+		for (; (str = scanstring(s, true)); ) {
+			val = enveval(e->env, str);
+			canonpath(val);
+			if (nodes.len == nodescap) {
+				nodescap = nodes.node ? nodescap * 2 : 32;
+				nodes.node = xreallocarray(nodes.node, nodescap, sizeof(nodes.node[0]));
+			}
+			nodes.node[nodes.len++] = mknode(val);
+		}
+	}
+	if (nodes.len)
+		edgeadddyndeps(e, nodes.node, nodes.len);
+
+	scannewline(s);
+	while (scanindent(s)) {
+		name = scanname(s);
+		if (strcmp(name, "restat") != 0)
+			fatal("unexpected variable '%s' in dyndep", name);
+		parselet(s, &str);
+		envaddvar(e->env, "restat", enveval(env, str));
+	}
+
+	e->flags |= FLAG_DYNDEP;
+}
+
+static void
+dyndepparse(const char *name)
+{
+	struct scanner s;
+	struct environment *env;
+	struct evalstring *str;
+	struct string *val;
+	bool version = false;
+	char *var;
+
+	scaninit(&s, name);
+
+	env = mkenv(NULL);
+	for (;;) {
+		switch (scankeyword(&s, &var)) {
+		case BUILD:
+			if (!version)
+				goto version;
+			dyndepparseedge(&s, env);
+			break;
+		case VARIABLE:
+			if (version)
+				scanerror(&s, "unexpected variable '%s'", var);
+			parselet(&s, &str);
+			val = enveval(env, str);
+			if (strcmp(var, "ninja_dyndep_version") == 0)
+				checkversion(val->s);
+			envaddvar(env, var, val);
+			version = true;
+			break;
+		case EOF:
+			if (!version)
+				goto version;
+			scanclose(&s);
+			return;
+		default:
+			scanerror(&s, "unexpected keyword");
+		}
+	}
+version:
+	scanerror(&s, "expected 'ninja_dyndep_version'");
+}
+
+bool
+dyndepload(struct dyndep *d, bool prune)
+{
+	const char *name;
+	struct edge *e;
+	struct node *n;
+	size_t i;
+
+	if (d->done)
+		return true;
+
+	name = d->node->path->s;
+
+	if (!d->node->gen)
+		fatal("dyndep not created by any action: '%s'", name);
+
+	if (!prune) {
+		/* only load dyndep file if its clean and nothing is blocking it */
+		if (d->node->gen->flags & FLAG_DIRTY || d->node->gen->nblock > 0)
+			return false;
+	} else {
+		nodestat(d->node);
+		if (d->node->mtime == MTIME_MISSING)
+			return false;
+	}
+
+	if (buildopts.explain)
+		warn("loading dyndep file: '%s'", name);
+
+	dyndepparse(name);
+
+	d->done = true;
+
+	if (prune)
+		return true;
+
+	/* verify that all nodes with this dyndep are loaded */
+	for (i = 0; i < d->nuse; i++) {
+		e = d->use[i];
+		if (!(e->flags & FLAG_DYNDEP))
+			fatal("target '%s' not mentioned in dyndep file '%s'",
+			    e->out[0]->path->s, d->node->path->s);
+	}
+	/* (re)-schedule the nodes updated by this dyndep */
+	for (i = 0; i < d->nupdate; i++) {
+		n = d->update[i];
+		/* only update the node if it was previously added to the build */
+		if (n->gen->flags & FLAG_WORK)
+			buildupdate(n);
+		else
+			buildadd(n);
+		n->gen->flags &= ~FLAG_DYNDEP;
+	}
+
+	return true;
+}

--- a/dyndep.h
+++ b/dyndep.h
@@ -1,0 +1,29 @@
+struct node;
+
+struct dyndep {
+	/* the node building the dyndep file */
+	struct node *node;
+
+	/* edges using this dyndep */
+	struct edge **use;
+	size_t nuse;
+
+	/* nodes this dyndep updated */
+	struct node **update;
+	size_t nupdate;
+
+	/* is this dyndep file already loaded */
+	_Bool done;
+
+	/* used for alldyndeps linked list */
+	struct dyndep *allnext;
+};
+
+void dyndepinit(void);
+
+/* create a new dyndep or return existing dyndep */
+struct dyndep *mkdyndep(struct node *);
+/* load the dyndep */
+bool dyndepload(struct dyndep *, bool);
+/* record the usage of a dyndep by an edge */
+void dyndepuse(struct dyndep *, struct edge *);

--- a/env.c
+++ b/env.c
@@ -246,6 +246,19 @@ edgevar(struct edge *e, char *var, bool escape)
 	return merge(str, n);
 }
 
+bool
+edgevarbool(struct edge *e, char *var)
+{
+	struct string *val;
+	bool rv;
+
+	val = edgevar(e, var, true);
+	if (!val)
+		return false;
+	rv = val->n > 0;
+	return rv;
+}
+
 static void
 addpool(struct pool *p)
 {

--- a/env.h
+++ b/env.h
@@ -42,6 +42,9 @@ struct pool *poolget(char *);
 /* evaluate and return an edge's variable, optionally shell-escaped */
 struct string *edgevar(struct edge *, char *, _Bool);
 
+/* evaluate and return an edge's boolean variable */
+_Bool edgevarbool(struct edge *, char *);
+
 extern struct environment *rootenv;
 extern struct rule phonyrule;
 extern struct pool consolepool;

--- a/graph.h
+++ b/graph.h
@@ -67,6 +67,7 @@ struct edge {
 		FLAG_CYCLE     = 1 << 5,  /* used for cycle detection */
 		FLAG_DEPS      = 1 << 6,  /* dependencies loaded */
 		FLAG_DYNDEP    = 1 << 7,  /* dyndep loaded */
+		FLAG_QUEUED    = 1 << 8,  /* edge is queued */
 	} flags;
 
 	/* used to coordinate ready work in build() */

--- a/log.c
+++ b/log.c
@@ -38,6 +38,7 @@ loginit(const char *builddir)
 	size_t sz = 0, nline, nentry, i;
 	struct edge *e;
 	struct node *n;
+	struct string *path;
 	int64_t mtime;
 
 	nline = 0;
@@ -80,8 +81,12 @@ loginit(const char *builddir)
 		if (!s)
 			continue;
 		n = nodeget(s, 0);
-		if (!n || !n->gen)
-			continue;
+		if (!n) {
+			path = mkstr(strlen(s));
+			memcpy(path->s, s, path->n);
+			path->s[path->n] = '\0';
+			n = mknode(path);
+		}
 		if (n->logmtime == MTIME_MISSING)
 			++nentry;
 		n->logmtime = mtime;

--- a/parse.c
+++ b/parse.c
@@ -233,7 +233,8 @@ parsepool(struct scanner *s, struct environment *env)
 static void
 checkversion(const char *ver)
 {
-	if (strcmp(ver, ninjaversion) > 0)
+	int nmajor, nminor = 0;
+	if (sscanf(ver, "%d.%d", &nmajor, &nminor) < 1 || (nmajor > 1) || (nminor > 10))
 		fatal("ninja_required_version %s is newer than %s", ver, ninjaversion);
 }
 

--- a/parse.c
+++ b/parse.c
@@ -3,13 +3,14 @@
 #include <string.h>
 #include <stdlib.h>
 #include "env.h"
+#include "dyndep.h"
 #include "graph.h"
 #include "parse.h"
 #include "scan.h"
 #include "util.h"
 
 struct parseoptions parseopts;
-const char *ninjaversion = "1.9.0";
+const char *ninjaversion = "1.10.0";
 struct node **deftarg;
 size_t ndeftarg;
 
@@ -71,7 +72,7 @@ parseedge(struct scanner *s, struct environment *env)
 	struct edge *e;
 	struct evalstring *out, *in, *str, **end;
 	char *name;
-	struct string *val;
+	struct string *val, *dyndep;
 	struct node *n;
 	size_t i;
 	int p;
@@ -102,7 +103,7 @@ parseedge(struct scanner *s, struct environment *env)
 			pushstr(&end, str);
 		p = scanpipe(s, 2);
 	}
-	e->inorderidx = e->nin;
+	e->indynidx = e->inorderidx = e->nin;
 	if (p == 2) {
 		for (; (str = scanstring(s, true)); ++e->nin)
 			pushstr(&end, str);
@@ -134,6 +135,9 @@ parseedge(struct scanner *s, struct environment *env)
 			++i;
 		}
 	}
+	e->outdynidx = e->nout;
+
+	dyndep = edgevar(e, "dyndep", true);
 
 	e->in = xreallocarray(NULL, e->nin, sizeof(e->in[0]));
 	for (i = 0; i < e->nin; in = str, ++i) {
@@ -143,7 +147,14 @@ parseedge(struct scanner *s, struct environment *env)
 		n = mknode(val);
 		e->in[i] = n;
 		nodeuse(n, e);
+		if (dyndep && strcmp(n->path->s, dyndep->s) == 0) {
+			dyndepuse(mkdyndep(n), e);
+			dyndep = NULL;
+		}
 	}
+
+	if (dyndep)
+		fatal("dyndep '%s' not in inputs", dyndep->s);
 
 	val = edgevar(e, "pool", true);
 	if (val)

--- a/samu.c
+++ b/samu.c
@@ -8,6 +8,7 @@
 #include "arg.h"
 #include "build.h"
 #include "deps.h"
+#include "dyndep.h"
 #include "env.h"
 #include "graph.h"
 #include "log.h"
@@ -230,6 +231,7 @@ retry:
 	graphinit();
 	envinit();
 	parseinit();
+	dyndepinit();
 
 	/* parse the manifest */
 	parse(manifest, rootenv);

--- a/tool.c
+++ b/tool.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include "arg.h"
 #include "env.h"
+#include "dyndep.h"
 #include "graph.h"
 #include "tool.h"
 #include "util.h"
@@ -32,6 +33,9 @@ cleanedge(struct edge *e)
 {
 	int ret = 0;
 	size_t i;
+
+	if (e->dyndep)
+		dyndepload(e->dyndep, true);
 
 	for (i = 0; i < e->nout; ++i) {
 		if (cleanpath(e->out[i]->path) < 0)


### PR DESCRIPTION
```ninja
rule untar
  command = tar xf $in && touch $out
rule scantar
  command = printf "ninja_dyndep_version = 1\nbuild %s | %s: dyndep\n  restat = true\n" "$stamp" $
  "$$(tar tf $in | tr "\n" " ")" >$out.tmp && mv $out.tmp $out
rule cat
  command = cat $in >$out.tmp && mv $out.tmp $out
build foo.tar.dd: scantar foo.tar
  stamp = foo.tar.stamp
build foo.tar.stamp: untar foo.tar || foo.tar.dd
  dyndep = foo.tar.dd
```

```
samurai$ tar tf test/foo.tar
foo
bar
```
```
samurai$ ./samu -C test/ -d explain
samu: explain foo.tar.dd: missing
samu: explain foo.tar.stamp: missing
[1/2] printf "ninja_dyndep_version = 1\nbuild %s | %s: dyndep\n  restat = true\n" "foo.tar.stamp" "$(tar tf foo.tar | tr "\n" " ")" >foo.tar.dd.tmp && mv foo.tar.dd.tmp foo.tar.dd
samu: loading dyndep file: 'foo.tar.dd'
[2/2] tar xf foo.tar && touch foo.tar.stamp
```
```
samurai$ ./samu -C test/ -d explain
samu: loading dyndep file: 'foo.tar.dd'
samu: nothing to do
```
```
samurai$ rm test/foo
samurai$ ./samu -C test/ -d explain
samu: loading dyndep file: 'foo.tar.dd'
samu: explain foo: missing
samu: explain foo.tar.stamp: output of generating action is dirty
samu: explain bar: output of generating action is dirty
[1/1] tar xf foo.tar && touch foo.tar.stamp
```
```
samurai$ ./samu -C test/ -d explain -t clean
samu: loading dyndep file: 'foo.tar.dd'
remove foo.tar.stamp
remove foo
remove bar
remove foo.tar.dd
```