### PR TITLE
Implement more tools as well as -n

### DIFF
--- a/build.h
+++ b/build.h
@@ -14,3 +14,5 @@ void buildreset(void);
 void buildadd(struct node *);
 /* execute rules to build the scheduled targets */
 void build(void);
+/* execute a function with all default nodes */
+void dodefault(void (*fn)(struct node *));

--- a/build.h
+++ b/build.h
@@ -2,7 +2,7 @@ struct node;
 
 struct buildoptions {
 	size_t maxjobs, maxfail;
-	_Bool verbose, explain, keepdepfile, keeprsp;
+	_Bool verbose, explain, keepdepfile, keeprsp, dryrun;
 	const char *statusfmt;
 };
 

--- a/graph.c
+++ b/graph.c
@@ -71,7 +71,7 @@ mknode(struct string *path)
 }
 
 struct node *
-nodeget(char *path, size_t len)
+nodeget(const char *path, size_t len)
 {
 	struct hashtablekey k;
 

--- a/graph.h
+++ b/graph.h
@@ -73,7 +73,7 @@ void graphinit(void);
 /* create a new node or return existing node */
 struct node *mknode(struct string *);
 /* lookup a node by name; returns NULL if it does not exist */
-struct node *nodeget(char *, size_t);
+struct node *nodeget(const char *, size_t);
 /* update the mtime field of a node */
 void nodestat(struct node *);
 /* get a node's path, possibly escaped for the shell */

--- a/samu.1
+++ b/samu.1
@@ -1,4 +1,4 @@
-.Dd October 23, 2020
+.Dd October 24, 2020
 .Dt SAMU 1
 .Os
 .Sh NAME
@@ -12,7 +12,7 @@
 .Op Fl j Ar maxjobs
 .Op Fl k Ar maxfail
 .Op Fl w Ar warnflag=action
-.Op Fl v
+.Op Fl nv
 .Op Ar target...
 .Nm
 .Op Fl C Ar dir
@@ -144,6 +144,8 @@ Allow up to
 .Ar maxfail
 job failures.
 If negative or zero, allow any number of job failures.
+.It Fl n
+Do not actually execute the commands or update the log.
 .It Fl v
 Print full commands instead of just
 .Sy description .

--- a/samu.c
+++ b/samu.c
@@ -37,8 +37,8 @@ getbuilddir(void)
 	return builddir->s;
 }
 
-static void
-builddefault(void)
+void
+dodefault(void (*fn)(struct node *))
 {
 	struct edge *e;
 	struct node *n;
@@ -46,14 +46,14 @@ builddefault(void)
 
 	if (ndeftarg > 0) {
 		for (i = 0; i < ndeftarg; ++i)
-			buildadd(deftarg[i]);
+			fn(deftarg[i]);
 	} else {
 		/* by default build all nodes which are not used by any edges */
 		for (e = alledges; e; e = e->allnext) {
 			for (i = 0; i < e->nout; ++i) {
 				n = e->out[i];
 				if (n->nuse == 0)
-					buildadd(n);
+					fn(n);
 			}
 		}
 	}
@@ -271,7 +271,7 @@ retry:
 			buildadd(n);
 		}
 	} else {
-		builddefault();
+		dodefault(buildadd);
 	}
 	build();
 	logclose();

--- a/samu.c
+++ b/samu.c
@@ -20,7 +20,7 @@ const char *argv0;
 static void
 usage(void)
 {
-	fprintf(stderr, "usage: %s [-C dir] [-f buildfile] [-j maxjobs] [-k maxfail]\n", argv0);
+	fprintf(stderr, "usage: %s [-C dir] [-f buildfile] [-j maxjobs] [-k maxfail] [-n]\n", argv0);
 	exit(2);
 }
 
@@ -186,6 +186,9 @@ main(int argc, char *argv[])
 		warn("job scheduling based on load average is not implemented");
 		EARGF(usage());
 		break;
+	case 'n':
+		buildopts.dryrun = true;
+		break;
 	case 't':
 		tool = toolget(EARGF(usage()));
 		goto argdone;
@@ -251,7 +254,8 @@ retry:
 			if (n->gen->flags & FLAG_DIRTY_OUT || n->gen->nprune > 0) {
 				if (++tries > 100)
 					fatal("manifest '%s' dirty after 100 tries", manifest);
-				goto retry;
+				if (!buildopts.dryrun)
+					goto retry;
 			}
 			/* manifest was pruned; reset state, then continue with build */
 			buildreset();


### PR DESCRIPTION
This pull request brings a few more ninja features to samurai, namely:
* `-t list`
* `-t query` (QEMU uses it to bridge Make with ninja)
* dry-run (`-n`)
* `-t commands`, which is effectively a variation on dry-run