### PR TITLE
Fix floating point exception

### DIFF
--- a/build.c
+++ b/build.c
@@ -226,7 +226,11 @@ formatstatus(char *buf, size_t len)
 			n = snprintf(buf, len, "%zu", ntotal - nstarted);
 			break;
 		case 'p':
-			n = snprintf(buf, len, "%3zu%%", 100 * nfinished / ntotal);
+			if (ntotal > 0) {
+				n = snprintf(buf, len, "%3zu%%", 100 * nfinished / ntotal);
+			} else {
+				n = snprintf(buf, len, "  0%%");
+			}
 			break;
 		case 'o':
 			if (clock_gettime(CLOCK_MONOTONIC, &endtime) != 0) {


### PR DESCRIPTION
Samu dies with SIGFPE when NINJA_STATUS="%p [%s/%t]" with a basically
empty build file:

	build all: phony

This happens for example during the gnome-backgrounds build.

Found during a FreeBSD Ports exp-run that uses samurai instead of ninja:

http://package18.nyi.freebsd.org/data/122amd64-default-foo/2021-04-04_07h37m38s/logs/errors/gnome-backgrounds-3.38.0.log