### PR TITLE
build: Add DOCDIR.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@
 
 PREFIX=/usr/local
 BINDIR=$(PREFIX)/bin
-MANDIR=$(PREFIX)/share/man
+DATADIR=$(PREFIX)/share
+DOCDIR=$(DATADIR)/doc/samurai
+MANDIR=$(DATADIR)/man
 ALL_CFLAGS=$(CFLAGS) -std=c99 -Wall -Wextra -Wpedantic -Wno-unused-parameter
 OBJ=\
 	build.o\
@@ -45,6 +47,9 @@ $(OBJ): $(HDR)
 install: samu samu.1
 	mkdir -p $(DESTDIR)$(BINDIR)
 	cp samu $(DESTDIR)$(BINDIR)/
+	mkdir -p $(DESTDIR)$(DOCDIR)
+	cp LICENSE $(DESTDIR)$(DOCDIR)
+	cp README.md $(DESTDIR)$(DOCDIR)
 	mkdir -p $(DESTDIR)$(MANDIR)/man1
 	cp samu.1 $(DESTDIR)$(MANDIR)/man1/
 


### PR DESCRIPTION
This adds `DOCDIR` and `DATADIR` which defaults to `$(PREFIX)/share` and `$(DATADIR)/doc/samurai` respectively as per the GNU install standards.

https://www.gnu.org/software/make/manual/html_node/Directory-Variables.html

Adding `DATAROOTDIR` is probably not needed since samurai does not ship any project specific data files.

Note: Any distros or other users that ship samurai without including the license file are technically committing a license violation of all four included licenses.