### PR TITLE
manual: Use Pq macro to parenthesize link.

### DIFF
--- a/samu.1
+++ b/samu.1
@@ -91,7 +91,7 @@ tool is used, a list of shell commands used to build the specified
 If the
 .Cm compdb
 tool is used, a compilation database
-.Lk ( https://clang.llvm.org/docs/JSONCompilationDatabase.html )
+.Pq Lk https://clang.llvm.org/docs/JSONCompilationDatabase.html
 is printed instead.
 .Pp
 If the


### PR DESCRIPTION
This fixes a visual bug in how the man page renders on my Linux machine (which uses groff(1) and not mandoc(1)). This is how it looks in master:
![image](https://user-images.githubusercontent.com/29077900/135786341-594ad7f4-2362-4d45-b30a-218905ea2922.png)

Not sure if this is a groff bug but the patch makes it work with both mandoc(1) and groff(1)