### PR TITLE
Load average option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ It is feature-complete and supports most of the same options as ninja.
 
 samurai requires various POSIX.1-2008 interfaces.
 
+Scheduling jobs based on load average requires through the non-standard, but
+widely available `getloadavg` function. This feature can be disabled by
+defining the `NO_GETLOADAVG` macro when calling the C compiler.
+
 ## Differences from ninja
 
 samurai tries to match ninja behavior as much as possible, but there

--- a/build.c
+++ b/build.c
@@ -1,4 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
+#ifndef NO_GETLOADAVG
+#define _BSD_SOURCE /* for getloadavg */
+#endif
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
@@ -520,12 +523,28 @@ done:
 	return false;
 }
 
+#ifndef NO_GETLOADAVG
+/* Queries the system load average. */
+static double
+queryload(void)
+{
+	double load;
+
+	if (getloadavg(&load, 1) == -1) {
+		warn("getloadavg:");
+		load = 100.0;
+	}
+
+	return load;
+}
+#endif
+
 void
 build(void)
 {
 	struct job *jobs = NULL;
 	struct pollfd *fds = NULL;
-	size_t i, next = 0, jobslen = 0, numjobs = 0, numfail = 0;
+	size_t i, next = 0, jobslen = 0, maxjobs = buildopts.maxjobs, numjobs = 0, numfail = 0;
 	struct edge *e;
 
 	if (ntotal == 0) {
@@ -538,8 +557,13 @@ build(void)
 
 	nstarted = 0;
 	for (;;) {
+#ifndef NO_GETLOADAVG
+		/* limit number of of jobs based on load */
+		if (buildopts.maxload)
+			maxjobs = queryload() > buildopts.maxload ? 1 : buildopts.maxjobs;
+#endif
 		/* start ready edges */
-		while (work && numjobs < buildopts.maxjobs && numfail < buildopts.maxfail) {
+		while (work && numjobs < maxjobs && numfail < buildopts.maxfail) {
 			e = work;
 			work = work->worknext;
 			if (e->rule != &phonyrule && buildopts.dryrun) {
@@ -578,7 +602,7 @@ build(void)
 		}
 		if (numjobs == 0)
 			break;
-		if (poll(fds, jobslen, -1) < 0)
+		if (poll(fds, jobslen, 5000) < 0)
 			fatal("poll:");
 		for (i = 0; i < jobslen; ++i) {
 			if (!fds[i].revents || jobwork(&jobs[i]))

--- a/build.h
+++ b/build.h
@@ -4,6 +4,7 @@ struct buildoptions {
 	size_t maxjobs, maxfail;
 	_Bool verbose, explain, keepdepfile, keeprsp, dryrun;
 	const char *statusfmt;
+	double maxload;
 };
 
 extern struct buildoptions buildopts;

--- a/samu.1
+++ b/samu.1
@@ -11,6 +11,7 @@
 .Op Fl f Ar buildfile
 .Op Fl j Ar maxjobs
 .Op Fl k Ar maxfail
+.Op Fl l Ar maxload
 .Op Fl w Ar warnflag=action
 .Op Fl nv
 .Op Ar target...
@@ -163,6 +164,10 @@ Allow up to
 .Ar maxfail
 job failures.
 If negative or zero, allow any number of job failures.
+.It Fl l
+Do not spawn new jobs if the system load percentage is greater than
+.Ar maxload .
+If zero, spawn jobs as soon as possible.
 .It Fl n
 Do not actually execute the commands or update the log.
 .It Fl v
@@ -217,9 +222,10 @@ that get applied before those specified on the command-line.
 The only options allowed in
 .Ev SAMUFLAGS
 are
-.Fl v
+.Fl v ,
+.Fl j
 and
-.Fl j .
+.Fl l .
 .It Ev NINJA_STATUS
 The status output printed to the left of each rule description, using printf-like conversion specifiers.
 If unset, the default is "[%s/%t] ".


### PR DESCRIPTION
This is an alternative implementation of #41, and owes quite a bit of code to #50.

This avoids having multiple threads and instead relies on making `poll` time out.

I'm not sure of the best way to guard the load-average-using code, though. There doesn't seem to be a macro associated with it (and forgive me if my lack of experience with C is showing). That code is still unguarded in this PR.