### PR TITLE
build: Update warning flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 PREFIX=/usr/local
 BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man
-ALL_CFLAGS=$(CFLAGS) -std=c99 -Wall -Wextra -Wpedantic -Wno-unused-parameter
+ALL_CFLAGS=$(CFLAGS) -std=c99 -Wall -Wextra -Wshadow -Wpedantic -Wno-unused-parameter
 OBJ=\
 	build.o\
 	deps.o\

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 PREFIX=/usr/local
 BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man
-ALL_CFLAGS=$(CFLAGS) -std=c99 -Wall -Wextra -Wshadow -Wpedantic -Wno-unused-parameter
+ALL_CFLAGS=$(CFLAGS) -std=c99 -Wall -Wextra -Wshadow -Wmissing-prototypes -Wpedantic -Wno-unused-parameter
 OBJ=\
 	build.o\
 	deps.o\

--- a/build.c
+++ b/build.c
@@ -1,6 +1,12 @@
 #define _POSIX_C_SOURCE 200809L
+/* expose getloadavg */
 #ifndef NO_GETLOADAVG
-#define _BSD_SOURCE /* for getloadavg */
+#if defined(__APPLE__) && defined(__MACH__)
+#define _DARWIN_C_SOURCE
+#else
+#define _BSD_SOURCE
+#define _DEFAULT_SOURCE /* silence glibc >= 2.19 warning */
+#endif
 #endif
 #include <errno.h>
 #include <fcntl.h>

--- a/samu.c
+++ b/samu.c
@@ -203,8 +203,8 @@ main(int argc, char *argv[])
 argdone:
 	if (!buildopts.maxjobs) {
 #ifdef _SC_NPROCESSORS_ONLN
-		int n = sysconf(_SC_NPROCESSORS_ONLN);
-		switch (n) {
+		int proc = sysconf(_SC_NPROCESSORS_ONLN);
+		switch (proc) {
 		case -1: case 0: case 1:
 			buildopts.maxjobs = 2;
 			break;
@@ -212,7 +212,7 @@ argdone:
 			buildopts.maxjobs = 3;
 			break;
 		default:
-			buildopts.maxjobs = n + 2;
+			buildopts.maxjobs = proc + 2;
 			break;
 		}
 #else


### PR DESCRIPTION
This has 3 changes.

~~1. Remove `-Wno-unused-parameter`. There are currently no warnings and its probably better to solve these with `if (foo) {}` in the cases they exist to prevent hiding legitimate warnings.~~
2. Adds `-Wshadow` and fixes the one warning revealed by both gcc and clang.
3. Adds `-Wmissing-prototypes` which doesn't reveal any existing warnings, but it would be nice to not inadvertently introduce it in the future.
4. Fixes a `-Wcpp` warning.

This was tested on Slackware with gcc-11.2.0/clang-13.0.0 and Gentoo with gcc-11.3.0/clang-14.0.6.

The fixed `-Wshadow` warning:
```
samu.c: In function ‘main’:
samu.c:187:21: warning: declaration of ‘n’ shadows a previous local [-Wshadow]
  187 |                 int n = sysconf(_SC_NPROCESSORS_ONLN);
      |                     ^
samu.c:126:22: note: shadowed declaration is here
  126 |         struct node *n;
      |                      ^
```
```
In file included from /usr/include/errno.h:25,
                 from build.c:5:
/usr/include/features.h:187:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
  187 | # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
      |   ^~~~~~~
```