### PR TITLE
Support for GNU Make jobserver

### DIFF
--- a/build.c
+++ b/build.c
@@ -36,6 +36,7 @@ static struct edge *work;
 static size_t nstarted, nfinished, ntotal;
 static bool consoleused;
 static struct timespec starttime;
+static char gmaketokens[512], *gmakelatest = gmaketokens;
 
 void
 buildreset(void)
@@ -322,6 +323,15 @@ jobstart(struct job *j, struct edge *e)
 		warn("posix_spawn_file_actions_addclose:");
 		goto err3;
 	}
+	if (buildopts.gmakepipe[0] >= 0) {
+		/* do not allow children to steal GNU/tokens */
+		for (i = 0; i < 2; ++i) {
+			if ((errno = posix_spawn_file_actions_addclose(&actions, buildopts.gmakepipe[i]))) {
+				warn("posix_spawn_file_actions_addclose:");
+				goto err3;
+			}
+		}
+	}
 	if (e->pool != &consolepool) {
 		if ((errno = posix_spawn_file_actions_addopen(&actions, 0, "/dev/null", O_RDONLY, 0))) {
 			warn("posix_spawn_file_actions_addopen:");
@@ -541,14 +551,24 @@ queryload(void)
 #endif
 }
 
+/* returns remaining GNU/tokens */
+static void
+returngmake(void)
+{
+	if (buildopts.gmakepipe[1] >= 0) {
+		if (write(buildopts.gmakepipe[1], gmaketokens, gmakelatest - gmaketokens) < 0)
+			warn("last write to jobserver:");
+	}
+}
+
 void
 build(void)
 {
 	struct job *jobs = NULL;
 	struct pollfd *fds = NULL, tokenin = { .fd = -1, .events = POLLIN };
-	size_t i, next = 0, jobslen = 0, maxjobs = buildopts.maxjobs, numjobs = 0, numfail = 0, gmakeread;
+	size_t i, next = 0, jobslen = 0, maxjobs = buildopts.maxjobs, numjobs = 0, numfail = 0;
+	ssize_t gmakeread;
 	struct edge *e;
-	char gmaketokens[512], *gmakelatest = gmaketokens;
 
 	if (ntotal == 0) {
 		warn("nothing to do");
@@ -556,8 +576,12 @@ build(void)
 	}
 
 	if (buildopts.gmakepipe[0] >= 0) {
-		maxjobs = 1; /* will change dynamically as tokens are exchanged */
-		tokenin.fd = buildopts.gmakepipe[0];
+		if (atexit(returngmake) == 0) {
+			maxjobs = 1; /* will change dynamically as tokens are exchanged */
+			tokenin.fd = buildopts.gmakepipe[0];
+		} else {
+			warn("unable to register an atexit() function");
+		}
 	}
 
 	clock_gettime(CLOCK_MONOTONIC, &starttime);
@@ -568,7 +592,7 @@ build(void)
 		/* see if GNU/make has authorized more jobs */
 		if (poll(&tokenin, 1, 0) > 0) {
 			gmakeread = gmakelatest - gmaketokens;
-			gmakeread = read(buildopts.gmakepipe[0], gmakelatest, 512 - gmakeread > ntotal - nstarted ? ntotal - nstarted : 512 - gmakeread);
+			gmakeread = read(buildopts.gmakepipe[0], gmakelatest, 512 - (size_t)gmakeread > ntotal - nstarted ? ntotal - nstarted : 512 - gmakeread);
 			if (gmakeread < 0) {
 				warn("read from jobserver:");
 				gmakeread = 0;
@@ -637,12 +661,6 @@ build(void)
 				}
 				--maxjobs;
 			}
-		}
-	}
-	/* return remaining GNU/tokens */
-	if (buildopts.gmakepipe[1] >= 0) {
-		if (write(buildopts.gmakepipe[1], gmaketokens, gmakelatest - gmaketokens) < 0) {
-			warn("last write to jobserver:");
 		}
 	}
 	for (i = 0; i < jobslen; ++i)

--- a/build.c
+++ b/build.c
@@ -31,7 +31,7 @@ struct job {
 	bool failed;
 };
 
-struct buildoptions buildopts = {.maxfail = 1};
+struct buildoptions buildopts = {.maxfail = 1, .gmakepipe = {-1, -1} };
 static struct edge *work;
 static size_t nstarted, nfinished, ntotal;
 static bool consoleused;
@@ -545,13 +545,19 @@ void
 build(void)
 {
 	struct job *jobs = NULL;
-	struct pollfd *fds = NULL;
-	size_t i, next = 0, jobslen = 0, maxjobs = buildopts.maxjobs, numjobs = 0, numfail = 0;
+	struct pollfd *fds = NULL, tokenin = { .fd = -1, .events = POLLIN };
+	size_t i, next = 0, jobslen = 0, maxjobs = buildopts.maxjobs, numjobs = 0, numfail = 0, gmakeread;
 	struct edge *e;
+	char gmaketokens[512], *gmakelatest = gmaketokens;
 
 	if (ntotal == 0) {
 		warn("nothing to do");
 		return;
+	}
+
+	if (buildopts.gmakepipe[0] >= 0) {
+		maxjobs = 1; /* will change dynamically as tokens are exchanged */
+		tokenin.fd = buildopts.gmakepipe[0];
 	}
 
 	clock_gettime(CLOCK_MONOTONIC, &starttime);
@@ -559,6 +565,17 @@ build(void)
 
 	nstarted = 0;
 	for (;;) {
+		/* see if GNU/make has authorized more jobs */
+		if (poll(&tokenin, 1, 0) > 0) {
+			gmakeread = gmakelatest - gmaketokens;
+			gmakeread = read(buildopts.gmakepipe[0], gmakelatest, 512 - gmakeread > ntotal - nstarted ? ntotal - nstarted : 512 - gmakeread);
+			if (gmakeread < 0) {
+				warn("read from jobserver:");
+				gmakeread = 0;
+			}
+			gmakelatest += gmakeread;
+			maxjobs += gmakeread;
+		}
 		/* limit number of of jobs based on load */
 		if (buildopts.maxload)
 			maxjobs = queryload() > buildopts.maxload ? 1 : buildopts.maxjobs;
@@ -613,6 +630,19 @@ build(void)
 			next = i;
 			if (jobs[i].failed)
 				++numfail;
+			/* must return the GNU/tokens once a job is done */
+			if (buildopts.gmakepipe[1] > 0 && gmakelatest != gmaketokens) {
+				if (write(buildopts.gmakepipe[1], --gmakelatest, 1) < 0) {
+					warn("write to jobserver:");
+				}
+				--maxjobs;
+			}
+		}
+	}
+	/* return remaining GNU/tokens */
+	if (buildopts.gmakepipe[1] >= 0) {
+		if (write(buildopts.gmakepipe[1], gmaketokens, gmakelatest - gmaketokens) < 0) {
+			warn("last write to jobserver:");
 		}
 	}
 	for (i = 0; i < jobslen; ++i)

--- a/build.h
+++ b/build.h
@@ -5,6 +5,7 @@ struct buildoptions {
 	_Bool verbose, explain, keepdepfile, keeprsp, dryrun;
 	const char *statusfmt;
 	double maxload;
+	int gmakepipe[2];
 };
 
 extern struct buildoptions buildopts;

--- a/samu.c
+++ b/samu.c
@@ -99,11 +99,10 @@ jobserverflags(const char *flag)
 	if (!flag)
 		return;
 	if (sscanf(flag, "%d,%d", &rfd, &wfd) == 2) {
-		/* prepare error message */
-		errno = EBADF;
+		;
 	} else if (strncmp(flag, "fifo:", 5) == 0) {
-		rfd = open(flag + 5, O_RDONLY);
-		wfd = open(flag + 5, O_WRONLY);
+		if ((rfd = wfd = open(flag + 5, O_RDWR)) == -1)
+			fatal("unable to open jobserver fifo:");
 	} else {
 		fatal("invalid jobserver parameter");
 	}
@@ -127,8 +126,8 @@ parsegmakeflags(char *env) {
 			buildopts.dryrun = true;
 		} else if (strncmp(arg, "-j", 2) == 0) {
 			jobsflag(arg + 2);
-		} else if (strncmp(arg, "--jobserver-auth=", 17) == 0 || strncmp(arg, "--jobserver-fds=", 16) == 0) {
-			jobserverflags(strchr(arg, '=')+1);
+		} else if (strncmp(arg, "--jobserver-auth=", 17) == 0) {
+			jobserverflags(arg + 17);
 		}
 		arg = strtok(NULL, " ");
 	}

--- a/samu.c
+++ b/samu.c
@@ -5,8 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>  /* for chdir */
-#include <poll.h>   /* for poll  */
-#include <fcntl.h> /* for open */
+#include <fcntl.h>   /* for open */
 #include "arg.h"
 #include "build.h"
 #include "deps.h"
@@ -127,7 +126,7 @@ parsegmakeflags(char *env) {
 		if (arg[0] && arg[0] != '-' && strchr(arg, 'n')) {
 			buildopts.dryrun = true;
 		} else if (strncmp(arg, "-j", 2) == 0) {
-			/* handled by parent process */
+			jobsflag(arg + 2);
 		} else if (strncmp(arg, "--jobserver-auth=", 17) == 0 || strncmp(arg, "--jobserver-fds=", 16) == 0) {
 			jobserverflags(strchr(arg, '=')+1);
 		}
@@ -248,14 +247,7 @@ main(int argc, char *argv[])
 		usage();
 	} ARGEND
 argdone:
-	if (buildopts.gmakepipe[0] >= 0) {
-		if (buildopts.maxjobs)
-			warn("ignoring -j setting as GNU Make job client is enabled");
-		if (buildopts.maxload)
-			warn("ignoring -l setting as GNU Make job client is enabled");
-		buildopts.maxjobs = -1;
-		buildopts.maxload = 0;
-	} else if (!buildopts.maxjobs) {
+	if (!buildopts.maxjobs) {
 #ifdef _SC_NPROCESSORS_ONLN
 		int nproc = sysconf(_SC_NPROCESSORS_ONLN);
 		switch (nproc) {


### PR DESCRIPTION
Quick and dirty implementation of #71, following the GNU Make 4.3 manual (Section 13.1.

TODO:
- [ ] `-l` and `-j` are ignored when jobserver options are active, though CMake team's proposed patch for Ninja instead ignores jobserver options whenever -j is given in the command line. Should we follow them?
- [x] Aborts whenever given jobserver FDs are closed/invalid. Should it be downgraded to warning?
- [x] Make sure it works with older GNU Make (pre-4.2, with different option names).
- [x] The `fifo:` protocol mentioned on #71.
- [x] Tokens should be returned to GNU Make when the program terminates. This is probably the biggest issue with this PR, but I'd like feedback on the "core" of the changes before embarking on rewriting `fatal` and installing signal handlers.