### PR TITLE
Enables getloadavg on Darwin

### DIFF
--- a/build.c
+++ b/build.c
@@ -1,6 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #ifndef NO_GETLOADAVG
 #define _BSD_SOURCE /* for getloadavg */
+#define _DARWIN_C_SOURCE /* for getloadavg */
 #endif
 #include <errno.h>
 #include <fcntl.h>


### PR DESCRIPTION
On darwin/macos, stdlib.h guards the definition of getloadavg with `#if !defined(_ANSI_SOURCE) && (!defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE)) ... #endif`.

Without this change samurai doesn't build on darwin (without `-DNO_GETLOADAVG`), e.g:

    build.c:535:6: error: implicit declaration of function 'getloadavg' is invalid in C99
        if (getloadavg(&load, 1) == -1) {
            ^

Thanks for an elegant ninja implementation!