### PR TITLE
build: Fix maxjob default detection

### DIFF
--- a/os-posix.c
+++ b/os-posix.c
@@ -83,3 +83,13 @@ https://www.illumos.org/issues/13327
 #endif
 	}
 }
+
+long
+osnproc(void)
+{
+#ifdef _SC_NPROCESSORS_ONLN
+	return sysconf(_SC_NPROCESSORS_ONLN);
+#else
+	return 1;
+#endif
+}

--- a/os.h
+++ b/os.h
@@ -7,3 +7,5 @@ void oschdir(const char *);
 int osmkdirs(struct string *, _Bool);
 /* queries the mtime of a file in nanoseconds since the UNIX epoch */
 int64_t osmtime(const char *);
+/* queries the number of online processors */
+long osnproc(void);

--- a/samu.c
+++ b/samu.c
@@ -200,8 +200,7 @@ main(int argc, char *argv[])
 	} ARGEND
 argdone:
 	if (!buildopts.maxjobs) {
-#ifdef _SC_NPROCESSORS_ONLN
-		long nproc = sysconf(_SC_NPROCESSORS_ONLN);
+		long nproc = osnproc();
 		switch (nproc) {
 		case -1: case 0: case 1:
 			buildopts.maxjobs = 2;
@@ -213,9 +212,6 @@ argdone:
 			buildopts.maxjobs = nproc + 2;
 			break;
 		}
-#else
-		buildopts.maxjobs = 2;
-#endif
 	}
 
 	buildopts.statusfmt = getenv("NINJA_STATUS");


### PR DESCRIPTION
The _SC_NPROCESSORS_ONLN macro is only available when including unistd.h, so the code that calculates the default of maxjobs from number of logical processors is never executed. It looks like this stopped working in 67435a344 "Separate out most OS-specific functions into os-posix.c".

Fix this by moving the sysconf call into os-posix.c, similar to other OS specifics.