### PR TITLE
Only link librt on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PREFIX=/usr/local
 BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man
 ALL_CFLAGS=$(CFLAGS) -std=c99 -Wall -Wextra -Wshadow -Wmissing-prototypes -Wpedantic -Wno-unused-parameter
-LDLIBS=-lrt
+LDLIBS=
 OBJ=\
 	build.o\
 	deps.o\
@@ -42,7 +42,8 @@ all: samu
 	$(CC) $(ALL_CFLAGS) -c -o $@ $<
 
 samu: $(OBJ)
-	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
+	case "`uname -s`" in Linux) rt=-lrt ;; *) rt= ;; esac; \
+	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS) $$rt
 
 $(OBJ): $(HDR)
 


### PR DESCRIPTION
`samurai` 1.3 links with `-lrt` unconditionally, which breaks macOS because Darwin does not provide `librt`.

This keeps `-lrt` on Linux and skips it on other platforms.

- https://github.com/Homebrew/homebrew-core/pull/276193
